### PR TITLE
feat(shared): scaffold shared types, enums, schemas, and constants

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,6 @@
-import { VERSION } from "@void-market/shared";
+import { VERSION, Commodity, TURN_COSTS, ActionType, GalaxyState } from "@void-market/shared";
 
 console.log(`@void-market/server v${VERSION}`);
+console.log(`Commodities: ${Object.values(Commodity).join(", ")}`);
+console.log(`Move cost: ${TURN_COSTS[ActionType.Move]} turn(s)`);
+console.log(`GalaxyState schema: ${GalaxyState.name}`);

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -1,0 +1,140 @@
+/**
+ * Game constants for Void Market.
+ * Single source of truth for balancing values used by both client and server.
+ */
+
+import { ActionType, Commodity, ShipClass } from "./enums.js";
+
+// ── Turn System ──────────────────────────────────────────────────────────────
+
+/** Milliseconds between turn regeneration ticks. */
+export const TURN_REGEN_INTERVAL_MS = 90_000;
+
+/** Maximum turns a player can bank. */
+export const MAX_TURN_BANK = 2_000;
+
+/** Starting turns for a new player. */
+export const STARTING_TURNS = 500;
+
+/** Turn cost per action type. */
+export const TURN_COSTS: Readonly<Record<ActionType, number>> = {
+  [ActionType.Move]: 1,
+  [ActionType.Trade]: 2,
+  [ActionType.Dock]: 0,
+  [ActionType.Undock]: 0,
+  [ActionType.Scan]: 1,
+  [ActionType.Attack]: 15,
+  [ActionType.Retreat]: 3,
+  [ActionType.Deploy]: 5,
+  [ActionType.Colonize]: 50,
+  [ActionType.BuildDefense]: 50,
+  [ActionType.TransferCredits]: 0,
+};
+
+// ── Economy ──────────────────────────────────────────────────────────────────
+
+/** All tradeable commodities (order matters for UI display). */
+export const COMMODITIES = [
+  Commodity.FuelOre,
+  Commodity.Organics,
+  Commodity.Equipment,
+] as const;
+
+/** Starting credits for a new player. */
+export const STARTING_CREDITS = 10_000;
+
+/** Base price per commodity (used as anchor for dynamic pricing). */
+export const BASE_PRICES: Readonly<Record<Commodity, number>> = {
+  [Commodity.FuelOre]: 20,
+  [Commodity.Organics]: 35,
+  [Commodity.Equipment]: 70,
+};
+
+/** Maximum stock a port can hold per commodity. */
+export const MAX_PORT_STOCK = 5_000;
+
+// ── Galaxy ───────────────────────────────────────────────────────────────────
+
+/** Default number of sectors in a generated galaxy. */
+export const DEFAULT_SECTOR_COUNT = 500;
+
+/** Maximum warp connections per sector. */
+export const MAX_WARPS_PER_SECTOR = 6;
+
+/** Sector ID of the starting sector (Federation HQ / safe zone). */
+export const STARTING_SECTOR_ID = 1;
+
+// ── Ships ────────────────────────────────────────────────────────────────────
+
+export interface ShipSpec {
+  readonly cargoCapacity: number;
+  readonly maxShields: number;
+  readonly maxFighters: number;
+  readonly warpSpeed: number;
+  readonly cost: number;
+}
+
+/** Base ship specifications per class. */
+export const SHIP_SPECS: Readonly<Record<ShipClass, ShipSpec>> = {
+  [ShipClass.Scout]: {
+    cargoCapacity: 50,
+    maxShields: 100,
+    maxFighters: 0,
+    warpSpeed: 3,
+    cost: 0,
+  },
+  [ShipClass.Merchant]: {
+    cargoCapacity: 300,
+    maxShields: 200,
+    maxFighters: 50,
+    warpSpeed: 2,
+    cost: 50_000,
+  },
+  [ShipClass.Frigate]: {
+    cargoCapacity: 150,
+    maxShields: 500,
+    maxFighters: 200,
+    warpSpeed: 2,
+    cost: 100_000,
+  },
+  [ShipClass.Cruiser]: {
+    cargoCapacity: 200,
+    maxShields: 1_000,
+    maxFighters: 500,
+    warpSpeed: 1,
+    cost: 250_000,
+  },
+  [ShipClass.Dreadnought]: {
+    cargoCapacity: 500,
+    maxShields: 2_000,
+    maxFighters: 1_000,
+    warpSpeed: 1,
+    cost: 500_000,
+  },
+};
+
+// ── Server Tick Rates ────────────────────────────────────────────────────────
+
+/** Fast tick interval (player actions, movement). */
+export const FAST_TICK_MS = 1_000;
+
+/** Slow tick interval (economy restock, NPC actions). */
+export const SLOW_TICK_MS = 60_000;
+
+// ── Federation / Alliance ────────────────────────────────────────────────────
+
+/** Maximum members per alliance. */
+export const MAX_ALLIANCE_MEMBERS = 50;
+
+/** Diplomacy standing range. */
+export const MIN_STANDING = -10;
+export const MAX_STANDING = 10;
+
+/** Cooldown before standings can change again (ms). */
+export const STANDING_COOLDOWN_MS = 48 * 60 * 60 * 1_000; // 48 hours
+
+/** Cost to declare war (credits). */
+export const WAR_DECLARATION_COST = 100_000;
+
+/** Minimum war duration (ms). */
+export const MIN_WAR_DURATION_MS = 7 * 24 * 60 * 60 * 1_000; // 7 days

--- a/shared/src/enums.ts
+++ b/shared/src/enums.ts
@@ -1,0 +1,95 @@
+/**
+ * Core enumerations for Void Market.
+ * These define the vocabulary for client↔server communication and game state.
+ */
+
+/** Player actions that consume turns. */
+export enum ActionType {
+  Move = "move",
+  Trade = "trade",
+  Dock = "dock",
+  Undock = "undock",
+  Scan = "scan",
+  Attack = "attack",
+  Retreat = "retreat",
+  Deploy = "deploy",
+  Colonize = "colonize",
+  BuildDefense = "build_defense",
+  TransferCredits = "transfer_credits",
+}
+
+/** Wire-protocol message types for Colyseus room communication. */
+export enum MessageType {
+  // Galaxy room — navigation
+  JoinGalaxy = "join_galaxy",
+  LeaveGalaxy = "leave_galaxy",
+  PlayerMove = "player_move",
+  SectorScan = "sector_scan",
+
+  // Galaxy room — trading
+  TradeRequest = "trade_request",
+  TradeConfirm = "trade_confirm",
+  TradeCancel = "trade_cancel",
+
+  // Galaxy room — docking
+  DockRequest = "dock_request",
+  UndockRequest = "undock_request",
+
+  // Galaxy room — information
+  PortQuery = "port_query",
+  PlayerStatus = "player_status",
+
+  // Combat room
+  CombatStart = "combat_start",
+  CombatAction = "combat_action",
+  CombatEnd = "combat_end",
+
+  // Federation room
+  FederationChat = "federation_chat",
+  FederationInvite = "federation_invite",
+  FederationKick = "federation_kick",
+
+  // Server → client push
+  TurnUpdate = "turn_update",
+  ErrorMessage = "error_message",
+}
+
+/** Tradeable commodities in the three-commodity economy. */
+export enum Commodity {
+  FuelOre = "fuel_ore",
+  Organics = "organics",
+  Equipment = "equipment",
+}
+
+/** Port trading behavior for a given commodity. */
+export enum PortTradeType {
+  Buying = "buying",
+  Selling = "selling",
+}
+
+/** Classification of port types by what they buy/sell. */
+export enum PortClass {
+  /** Buys Fuel Ore, Sells Organics & Equipment */
+  Class1 = 1,
+  /** Buys Organics, Sells Fuel Ore & Equipment */
+  Class2 = 2,
+  /** Buys Equipment, Sells Fuel Ore & Organics */
+  Class3 = 3,
+  /** Buys Fuel Ore & Organics, Sells Equipment */
+  Class4 = 4,
+  /** Buys Fuel Ore & Equipment, Sells Organics */
+  Class5 = 5,
+  /** Buys Organics & Equipment, Sells Fuel Ore */
+  Class6 = 6,
+  /** Special — Buys Exotic Matter (late-game) */
+  Class0 = 0,
+}
+
+/** Ship classes available for progression. */
+export enum ShipClass {
+  Scout = "scout",
+  Merchant = "merchant",
+  Frigate = "frigate",
+  Cruiser = "cruiser",
+  Dreadnought = "dreadnought",
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,66 @@
 /**
  * @void-market/shared — Types, constants, and schemas shared across client and server.
  */
-export const VERSION = "0.0.1";
+export const VERSION = "0.0.2";
+
+// Enums
+export {
+  ActionType,
+  MessageType,
+  Commodity,
+  PortTradeType,
+  PortClass,
+  ShipClass,
+} from "./enums.js";
+
+// Constants
+export {
+  TURN_REGEN_INTERVAL_MS,
+  MAX_TURN_BANK,
+  STARTING_TURNS,
+  TURN_COSTS,
+  COMMODITIES,
+  STARTING_CREDITS,
+  BASE_PRICES,
+  MAX_PORT_STOCK,
+  DEFAULT_SECTOR_COUNT,
+  MAX_WARPS_PER_SECTOR,
+  STARTING_SECTOR_ID,
+  SHIP_SPECS,
+  FAST_TICK_MS,
+  SLOW_TICK_MS,
+  MAX_ALLIANCE_MEMBERS,
+  MIN_STANDING,
+  MAX_STANDING,
+  STANDING_COOLDOWN_MS,
+  WAR_DECLARATION_COST,
+  MIN_WAR_DURATION_MS,
+} from "./constants.js";
+export type { ShipSpec } from "./constants.js";
+
+// Types (pure interfaces — no runtime)
+export type {
+  Position,
+  WarpRoute,
+  TradeOffer,
+  TradeResult,
+  PortListing,
+  PortInfo,
+  PlayerAction,
+  CargoHold,
+  ShipInfo,
+  PlayerProfile,
+  SectorInfo,
+  SectorNode,
+  TurnStatus,
+  GameError,
+} from "./types.js";
+
+// Colyseus Schema classes
+export {
+  PlayerSchema,
+  ShipSchema,
+  PortSchema,
+  SectorSchema,
+  GalaxyState,
+} from "./schemas.js";

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -1,0 +1,66 @@
+/**
+ * Colyseus Schema base classes for Void Market.
+ *
+ * These are minimal scaffolds that prove the decorator pattern works.
+ * They will be fleshed out as game systems are implemented in Phase 1.
+ *
+ * Schema classes are the authoritative state objects synchronized
+ * from server → client via Colyseus delta compression.
+ */
+
+import { Schema, type, MapSchema, ArraySchema } from "@colyseus/schema";
+
+// ── Player ───────────────────────────────────────────────────────────────────
+
+export class PlayerSchema extends Schema {
+  @type("string") playerId: string = "";
+  @type("string") displayName: string = "";
+  @type("number") sectorId: number = 1;
+  @type("number") credits: number = 0;
+  @type("number") turnsRemaining: number = 0;
+  @type("string") shipClass: string = "scout";
+}
+
+// ── Ship ─────────────────────────────────────────────────────────────────────
+
+export class ShipSchema extends Schema {
+  @type("string") shipId: string = "";
+  @type("string") shipClass: string = "scout";
+  @type("string") name: string = "";
+  @type("number") shields: number = 0;
+  @type("number") fighters: number = 0;
+  @type("number") cargoFuelOre: number = 0;
+  @type("number") cargoOrganics: number = 0;
+  @type("number") cargoEquipment: number = 0;
+}
+
+// ── Port ─────────────────────────────────────────────────────────────────────
+
+export class PortSchema extends Schema {
+  @type("string") portId: string = "";
+  @type("string") name: string = "";
+  @type("number") sectorId: number = 0;
+  @type("uint8") portClass: number = 1;
+  @type("number") stockFuelOre: number = 0;
+  @type("number") stockOrganics: number = 0;
+  @type("number") stockEquipment: number = 0;
+}
+
+// ── Sector ───────────────────────────────────────────────────────────────────
+
+export class SectorSchema extends Schema {
+  @type("number") sectorId: number = 0;
+  @type("number") x: number = 0;
+  @type("number") y: number = 0;
+  @type("boolean") hasPort: boolean = false;
+  @type([PlayerSchema]) players = new ArraySchema<PlayerSchema>();
+}
+
+// ── Galaxy State (GalaxyRoom root state) ─────────────────────────────────────
+
+export class GalaxyState extends Schema {
+  @type({ map: SectorSchema }) sectors = new MapSchema<SectorSchema>();
+  @type({ map: PlayerSchema }) players = new MapSchema<PlayerSchema>();
+  @type({ map: PortSchema }) ports = new MapSchema<PortSchema>();
+  @type("number") tickCount: number = 0;
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,0 +1,137 @@
+/**
+ * TypeScript interfaces and type aliases for Void Market.
+ * Pure types — no runtime code, no Colyseus dependency.
+ */
+
+import type {
+  ActionType,
+  Commodity,
+  PortClass,
+  PortTradeType,
+  ShipClass,
+} from "./enums.js";
+
+// ── Spatial ──────────────────────────────────────────────────────────────────
+
+/** 2D position for rendering (not game-logic authoritative). */
+export interface Position {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** A directional warp connection between two sectors. */
+export interface WarpRoute {
+  readonly fromSectorId: number;
+  readonly toSectorId: number;
+}
+
+// ── Trading ──────────────────────────────────────────────────────────────────
+
+/** Client → server trade request payload. */
+export interface TradeOffer {
+  readonly portId: string;
+  readonly commodity: Commodity;
+  readonly quantity: number;
+  /** True = player is buying from port; false = player is selling to port. */
+  readonly buying: boolean;
+}
+
+/** Server → client response to a trade request. */
+export interface TradeResult {
+  readonly success: boolean;
+  readonly commodity: Commodity;
+  readonly quantity: number;
+  readonly totalPrice: number;
+  readonly newCredits: number;
+  readonly error?: string;
+}
+
+/** Snapshot of a port's current commodity offering. */
+export interface PortListing {
+  readonly commodity: Commodity;
+  readonly tradeType: PortTradeType;
+  readonly stock: number;
+  readonly price: number;
+}
+
+// ── Port ─────────────────────────────────────────────────────────────────────
+
+/** Lightweight port info visible during sector scan. */
+export interface PortInfo {
+  readonly portId: string;
+  readonly sectorId: number;
+  readonly name: string;
+  readonly portClass: PortClass;
+  readonly listings: readonly PortListing[];
+}
+
+// ── Player / Ship ────────────────────────────────────────────────────────────
+
+/** Player action message payload. */
+export interface PlayerAction {
+  readonly type: ActionType;
+  readonly payload?: Record<string, unknown>;
+}
+
+/** Cargo hold contents. */
+export type CargoHold = Readonly<Record<Commodity, number>>;
+
+/** Ship state visible to its owner. */
+export interface ShipInfo {
+  readonly shipId: string;
+  readonly shipClass: ShipClass;
+  readonly name: string;
+  readonly cargoCapacity: number;
+  readonly cargo: CargoHold;
+  readonly shields: number;
+  readonly maxShields: number;
+  readonly fighters: number;
+}
+
+/** Public player profile (visible to others). */
+export interface PlayerProfile {
+  readonly playerId: string;
+  readonly displayName: string;
+  readonly shipClass: ShipClass;
+  readonly sectorId: number;
+  readonly allianceId?: string;
+}
+
+// ── Galaxy / Sector ──────────────────────────────────────────────────────────
+
+/** Sector data as seen by a player (may be fog-of-war filtered). */
+export interface SectorInfo {
+  readonly sectorId: number;
+  readonly position: Position;
+  readonly warps: readonly number[];
+  readonly hasPort: boolean;
+  readonly players: readonly PlayerProfile[];
+  readonly portInfo?: PortInfo;
+}
+
+/** Lightweight sector node for galaxy map rendering. */
+export interface SectorNode {
+  readonly sectorId: number;
+  readonly position: Position;
+  readonly warps: readonly number[];
+  readonly hasPort: boolean;
+}
+
+// ── Turns ────────────────────────────────────────────────────────────────────
+
+/** Turn state pushed to client on every change. */
+export interface TurnStatus {
+  readonly turnsRemaining: number;
+  readonly maxTurns: number;
+  readonly regenRateMs: number;
+  readonly nextRegenAt: number;
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+/** Structured error sent from server to client. */
+export interface GameError {
+  readonly code: string;
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Implements **#4 — P0-2: Shared package scaffold with placeholder types**.

Adds foundational exports to `@void-market/shared` that server, client, and future systems depend on.

### What's included

| File | Contents |
|------|----------|
| `enums.ts` | `ActionType`, `MessageType`, `Commodity`, `PortTradeType`, `PortClass`, `ShipClass` |
| `constants.ts` | Turn system (regen, bank, costs), economy (base prices, stock), galaxy params, ship specs, tick rates, alliance params |
| `types.ts` | Pure TS interfaces: `Position`, `WarpRoute`, `TradeOffer`, `TradeResult`, `PortListing`, `PortInfo`, `PlayerAction`, `CargoHold`, `ShipInfo`, `PlayerProfile`, `SectorInfo`, `TurnStatus`, `GameError` |
| `schemas.ts` | Colyseus Schema base classes: `PlayerSchema`, `ShipSchema`, `PortSchema`, `SectorSchema`, `GalaxyState` with `@type` decorators |
| `index.ts` | Barrel export re-exporting all modules |

### Verification

- ✅ `npm run build` produces `.js` + `.d.ts` in `shared/dist/`
- ✅ Cross-workspace import from `@void-market/server` compiles and runs
- ✅ Colyseus Schema `@type` decorators work with `experimentalDecorators`

### Dependencies

- Adds `@colyseus/schema@^4.0.19` to `shared` workspace
- Enables `experimentalDecorators` in `shared/tsconfig.json`

Closes #4