### PR TITLE
ci: enhance CI pipeline with coverage and job summary (#9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,37 @@ jobs:
         run: npm run lint
 
       - name: Run tests
+        id: test
         run: npm run test
+
+      - name: Generate coverage report
+        if: always() && steps.test.outcome == 'success'
+        continue-on-error: true
+        run: npx vitest run --coverage --coverage.thresholds.100=false --coverage.thresholds.statements=0 --coverage.thresholds.branches=0 --coverage.thresholds.functions=0 --coverage.thresholds.lines=0
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## CI Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Step | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Install | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Build | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Lint | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.test.outcome }}" = "failure" ]; then
+            echo "| Test | ❌ |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| Test | ✅ |" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   create-failure-issue:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/dev'

--- a/.squad/agents/marathe/history.md
+++ b/.squad/agents/marathe/history.md
@@ -903,3 +903,20 @@ permissions:
 - `coverage/` was missing from `.gitignore` — added as housekeeping
 
 **PR:** #55 → `dev`
+
+### 2026-03-17: Issue #9 — CI Pipeline Enhancement
+
+**What:** Updated `.github/workflows/ci.yml` to add coverage artifact upload and job summary.
+
+**Changes:**
+- Added non-blocking coverage report generation (V8 provider, thresholds zeroed to avoid false failures)
+- Added `actions/upload-artifact@v4` step for coverage reports (14-day retention)
+- Added `$GITHUB_STEP_SUMMARY` table showing build/lint/test status
+- Preserved all existing functionality: `npm ci → build → lint → test`, failure-issue creation, version-bump
+
+**Key Learnings:**
+- `npm run test:coverage` (vitest with thresholds) exits code 1 at 79.59% statements (threshold 80%) — don't gate CI on coverage thresholds during early development
+- Coverage generation must override thresholds via CLI flags: `--coverage.thresholds.statements=0`
+- The existing CI was already well-structured; this was an enhancement pass, not a rewrite
+
+**PR:** #57 → `dev`

--- a/.squad/decisions/inbox/marathe-ci-pipeline.md
+++ b/.squad/decisions/inbox/marathe-ci-pipeline.md
@@ -1,0 +1,24 @@
+# Decision: CI Coverage Thresholds Non-Blocking
+
+**Date:** 2026-03-17  
+**Owner:** Marathe (DevOps)  
+**Status:** Proposed
+
+## Context
+
+The vitest coverage config in `vitest.config.ts` sets 80% thresholds for statements/branches/functions/lines. During Phase 0 scaffolding, the codebase sits at ~79.6% statements due to Colyseus Schema boilerplate in `shared/src/schemas.ts`.
+
+## Decision
+
+Coverage reports are generated in CI but thresholds **do not gate** the build. The `npm run test` step (without `--coverage`) is the merge gate. Coverage artifacts are uploaded for visibility.
+
+## Rationale
+
+- Phase 0 scaffolding code (schemas, enums) has low test coverage by design — it's declarative boilerplate
+- Blocking merges on coverage during early development creates false failures
+- Coverage artifacts still provide trend visibility without blocking velocity
+- Thresholds can be enforced once Phase 1 game logic establishes meaningful test targets
+
+## Revisit
+
+Re-evaluate after Phase 1 MVP ships. Consider enforcing thresholds once active game logic raises coverage naturally.


### PR DESCRIPTION
## Changes

Updates the existing CI workflow (`.github/workflows/ci.yml`) to improve visibility and artifact collection:

### What's new
- **Coverage report generation** — After tests pass, generates a V8 coverage report (non-blocking, won't fail the build)
- **Artifact upload** — Uploads coverage reports (lcov, json-summary) as workflow artifacts with 14-day retention
- **Job summary** — Adds a results table to the GitHub Actions summary for quick PR-visible build status

### What's preserved
- Core pipeline: `npm ci → build → lint → test` (unchanged)
- `npm run test` remains the gating step (coverage thresholds don't block merge)
- Failure-issue auto-creation on `dev` push failures
- Auto patch version bump on successful `dev` push
- SHA-pinned actions, npm cache, concurrency control, paths-ignore for docs/.squad

### Acceptance criteria
- [x] CI workflow runs on PRs to `dev` branch
- [x] `npm ci` installs all workspace dependencies
- [x] `npm run build` compiles all workspaces
- [x] `npm run lint` runs ESLint across workspaces
- [x] `npm run test` runs test suite
- [x] PR gate blocks merge on failure (build-test job gates version-bump and failure-issue)
- [x] Workflow preserves existing Azure OIDC + GitHub environments pattern (deploy workflows untouched)

### Local verification
All four pipeline steps pass locally: `npm ci && npm run build && npm run lint && npm run test` ✅

Closes #9