### PR TITLE
feat(client): scaffold Vite + React 18 + PixiJS 8 + Colyseus client

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -1018,3 +1018,25 @@ Risk renderer rendering phase can now adopt this pattern for armies/territories.
 **Impact:** Project status is now visible in GitHub issues board. Milestones track phase progress. Dependency graph shows blocking relationships.
 
 **Reference:** `.squad/decisions.md` → "Track Project Plan as GitHub Issues" for label taxonomy and conventions.
+
+## Learnings
+
+### 2026-03-18: Client Scaffold (Issue #6)
+
+**What I built:**
+- Vite + React 18 + PixiJS 8 + Colyseus.js client scaffold
+- Hybrid rendering: PixiJS canvas (starfield) as background, React DOM overlay on top
+- Connection status badge (React component) showing Colyseus connection lifecycle
+- Vite dev server on port 5173 with proxy to server on 2567
+
+**Key technical decisions:**
+- Client tsconfig uses `moduleResolution: "bundler"` + `noEmit: true` (Vite handles bundling, not tsc)
+- Removed client from root `tsc --build` references; root build runs `tsc --build && npm run build --workspace=client`
+- ESLint switched from `projectService` to per-workspace `project` configs for monorepo compatibility
+- PixiJS canvas mounts via React ref to avoid lifecycle conflicts
+
+**Gotchas:**
+- TypeScript shadows `.tsx` files when `.ts` file with same name exists — must delete old `main.ts` before `main.tsx` will be discovered
+- ESLint `projectService: true` can't discover non-composite tsconfigs in a monorepo; explicit per-workspace `project` paths work reliably
+- `composite: false` in client tsconfig requires also setting `declaration: false` and `declarationMap: false` (inherited from root)
+- npm workspace installs can sometimes not persist package.json changes; always verify after install

--- a/.squad/decisions/inbox/gately-client-scaffold.md
+++ b/.squad/decisions/inbox/gately-client-scaffold.md
@@ -1,0 +1,24 @@
+# Decision: Client Build Pipeline (Gately)
+
+**Date:** 2026-03-18
+**Status:** Implemented
+**Context:** Issue #6 — Client Scaffold
+
+## Decision
+
+The client workspace now uses Vite for building instead of `tsc --build`.
+
+**Changes to monorepo build:**
+- `client/tsconfig.json` uses `noEmit: true`, `composite: false`, `moduleResolution: "bundler"` — TypeScript is used only for type-checking, Vite handles bundling
+- Root `tsconfig.json` no longer references `client/` in its `references` array (only `shared` and `server`)
+- Root `package.json` build script: `tsc --build && npm run build --workspace=client`
+
+**Changes to ESLint:**
+- Switched from `projectService: true` to per-workspace `project` paths for type-aware linting
+- This was required because the TypeScript project service couldn't discover non-composite tsconfigs in the monorepo
+
+**Impact:** All agents should be aware that:
+1. `npm run build` from root still builds everything (shared + server via tsc, client via Vite)
+2. `npm run lint` from root still lints everything
+3. Client `npm run dev` starts Vite dev server on port 5173
+4. Client `npm run typecheck` runs `tsc --noEmit` for type checking without building

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Void Market</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #09090b; /* zinc-950 */
+        color: #fafafa;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+      }
+
+      #app {
+        width: 100%;
+        height: 100%;
+        position: relative;
+      }
+
+      /* PixiJS canvas fills the background */
+      #pixi-canvas {
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+      }
+
+      /* React DOM overlay sits on top */
+      #react-root {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+      }
+
+      #react-root > * {
+        pointer-events: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <div id="pixi-canvas"></div>
+      <div id="react-root"></div>
+    </div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -5,13 +5,26 @@
   "type": "module",
   "main": "./dist/main.js",
   "scripts": {
-    "build": "tsc --build",
-    "clean": "tsc --build --clean",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@void-market/shared": "*"
+    "@void-market/shared": "*",
+    "colyseus.js": "^0.16.0",
+    "pixi.js": "^8.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^6.0.0"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useRef } from "react";
+import { ConnectionStatusBadge } from "./components/ConnectionStatusBadge.js";
+import { initPixiApp } from "./game/PixiApp.js";
+
+export function App(): React.JSX.Element {
+  const pixiContainerRef = useRef<HTMLDivElement | null>(null);
+  const pixiInitRef = useRef(false);
+
+  useEffect(() => {
+    const container = pixiContainerRef.current;
+    if (!container || pixiInitRef.current) return;
+    pixiInitRef.current = true;
+
+    void initPixiApp(container);
+  }, []);
+
+  return (
+    <>
+      {/* PixiJS mounts into the canvas container via ref */}
+      <div
+        ref={pixiContainerRef}
+        style={{ position: "absolute", inset: 0, zIndex: 0 }}
+      />
+      {/* React DOM overlay */}
+      <ConnectionStatusBadge />
+    </>
+  );
+}

--- a/client/src/components/ConnectionStatusBadge.tsx
+++ b/client/src/components/ConnectionStatusBadge.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import type { ConnectionStatus } from "../network/client.js";
+import { connectToServer } from "../network/client.js";
+
+const STATUS_CONFIG: Record<ConnectionStatus, { label: string; color: string; pulse: boolean }> = {
+  disconnected: { label: "Disconnected", color: "#ef4444", pulse: false },
+  connecting: { label: "Connecting…", color: "#a78bfa", pulse: true },
+  connected: { label: "Connected", color: "#22c55e", pulse: false },
+  error: { label: "Connection Error", color: "#ef4444", pulse: false },
+};
+
+export function ConnectionStatusBadge(): React.JSX.Element {
+  const [status, setStatus] = useState<ConnectionStatus>("disconnected");
+  const [errorMsg, setErrorMsg] = useState<string>();
+
+  useEffect(() => {
+    void connectToServer((newStatus, err) => {
+      setStatus(newStatus);
+      if (err) setErrorMsg(err);
+    });
+  }, []);
+
+  const config = STATUS_CONFIG[status];
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 16,
+        left: 16,
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 16px",
+        borderRadius: 8,
+        background: "rgba(24, 24, 27, 0.8)",
+        backdropFilter: "blur(8px)",
+        border: "1px solid rgba(161, 161, 170, 0.2)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        fontSize: 14,
+        color: "#fafafa",
+        zIndex: 100,
+        pointerEvents: "auto",
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: config.color,
+          animation: config.pulse ? "pulse 1.5s ease-in-out infinite" : "none",
+        }}
+      />
+      <span>{config.label}</span>
+      {errorMsg && status === "error" && (
+        <span style={{ color: "#a1a1aa", fontSize: 12, marginLeft: 4 }}>({errorMsg})</span>
+      )}
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/client/src/game/PixiApp.ts
+++ b/client/src/game/PixiApp.ts
@@ -1,0 +1,61 @@
+import { Application, Graphics } from "pixi.js";
+
+const STAR_COUNT = 200;
+const BG_COLOR = 0x09090b; // zinc-950
+
+interface Star {
+  x: number;
+  y: number;
+  radius: number;
+  alpha: number;
+}
+
+function generateStars(width: number, height: number): Star[] {
+  return Array.from({ length: STAR_COUNT }, () => ({
+    x: Math.random() * width,
+    y: Math.random() * height,
+    radius: Math.random() * 1.5 + 0.5,
+    alpha: Math.random() * 0.7 + 0.3,
+  }));
+}
+
+export async function initPixiApp(container: HTMLElement): Promise<Application> {
+  const app = new Application();
+
+  await app.init({
+    background: BG_COLOR,
+    resizeTo: container,
+    antialias: true,
+    resolution: window.devicePixelRatio || 1,
+    autoDensity: true,
+  });
+
+  container.appendChild(app.canvas);
+
+  const stars = generateStars(app.screen.width, app.screen.height);
+  const starGraphics = new Graphics();
+  drawStars(starGraphics, stars);
+  app.stage.addChild(starGraphics);
+
+  // Subtle twinkle animation
+  let elapsed = 0;
+  app.ticker.add((ticker) => {
+    elapsed += ticker.deltaTime * 0.02;
+    starGraphics.clear();
+    for (const star of stars) {
+      const flicker = 0.5 + 0.5 * Math.sin(elapsed + star.x * 0.01 + star.y * 0.01);
+      const alpha = star.alpha * (0.6 + 0.4 * flicker);
+      starGraphics.circle(star.x, star.y, star.radius);
+      starGraphics.fill({ color: 0xfafafa, alpha });
+    }
+  });
+
+  return app;
+}
+
+function drawStars(graphics: Graphics, stars: Star[]): void {
+  for (const star of stars) {
+    graphics.circle(star.x, star.y, star.radius);
+    graphics.fill({ color: 0xfafafa, alpha: star.alpha });
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,3 +1,0 @@
-import { VERSION } from "@void-market/shared";
-
-console.log(`@void-market/client v${VERSION}`);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+const rootElement = document.getElementById("react-root");
+if (!rootElement) {
+  throw new Error("Missing #react-root element in index.html");
+}
+
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/client/src/network/client.ts
+++ b/client/src/network/client.ts
@@ -1,0 +1,41 @@
+import { Client } from "colyseus.js";
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
+
+export type StatusListener = (status: ConnectionStatus, error?: string) => void;
+
+const SERVER_WS_URL: string =
+  (import.meta.env.VITE_SERVER_URL as string | undefined) ??
+  `ws://${window.location.hostname}:2567`;
+
+let clientInstance: Client | null = null;
+
+export function getColyseusClient(): Client {
+  clientInstance ??= new Client(SERVER_WS_URL);
+  return clientInstance;
+}
+
+/**
+ * Attempt to connect to the GalaxyRoom.
+ * Calls `onStatus` with connection lifecycle events.
+ */
+export async function connectToServer(onStatus: StatusListener): Promise<void> {
+  const client = getColyseusClient();
+  onStatus("connecting");
+
+  try {
+    const room = await client.joinOrCreate("galaxy");
+    onStatus("connected");
+
+    room.onLeave(() => {
+      onStatus("disconnected");
+    });
+
+    room.onError((code, message) => {
+      onStatus("error", `Room error ${code}: ${message ?? "unknown"}`);
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    onStatus("error", message);
+  }
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,8 +2,15 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
   },
-  "include": ["src"],
-  "references": [{ "path": "../shared" }]
+  "include": ["src", "vite-env.d.ts"]
 }

--- a/client/vite-env.d.ts
+++ b/client/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react()],
+  root: path.resolve(import.meta.dirname, "."),
+  resolve: {
+    alias: {
+      "@void-market/shared": path.resolve(import.meta.dirname, "../shared/src"),
+    },
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:2567",
+        changeOrigin: true,
+      },
+      "/colyseus": {
+        target: "ws://localhost:2567",
+        ws: true,
+      },
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,7 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        projectService: true,
+        projectService: false,
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -45,20 +45,36 @@ export default tseslint.config(
   // Shared workspace overrides
   {
     files: ["shared/src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./shared/tsconfig.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {},
   },
 
   // Server workspace overrides
   {
     files: ["server/src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        project: "./server/tsconfig.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {},
   },
 
   // Client workspace overrides
-  // TODO: Add eslint-plugin-react and eslint-plugin-react-hooks
-  // when they support ESLint 10+ and React is adopted in client
   {
     files: ["client/src/**/*.ts", "client/src/**/*.tsx"],
+    languageOptions: {
+      parserOptions: {
+        project: "./client/tsconfig.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {},
   },
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "client"
   ],
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && npm run build --workspace=client",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "test:coverage": "vitest run --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "sourceMap": true,
     "composite": true
   },
-  "references": [{ "path": "shared" }, { "path": "server" }, { "path": "client" }],
+  "references": [{ "path": "shared" }, { "path": "server" }],
   "files": []
 }


### PR DESCRIPTION
## Summary
Closes #6

Client scaffold with hybrid rendering model: PixiJS 8 canvas for galaxy map, React 18 DOM overlay for HUD/UI.

## What's included
- **Vite dev server** on port 5173 with React plugin and API proxy to server (2567)
- **PixiJS 8 starfield** — placeholder canvas with twinkling stars (proves PixiJS works)
- **React 18 entry point** — createRoot + App component with hybrid PixiJS/React rendering
- **Colyseus.js client** — connection to GalaxyRoom with status lifecycle
- **ConnectionStatusBadge** — React component showing Connecting/Connected/Disconnected/Error
- **Vite build** replaces tsc for client (bundler mode, noEmit)
- **ESLint** updated to per-workspace project configs for monorepo compat

## Acceptance Criteria
- [x] Vite dev server starts on port 5173
- [x] PixiJS 8 Application initialized and renders placeholder starfield
- [x] React 18 configured with Vite (JSX transform working)
- [x] Colyseus SDK installed, connects to server WebSocket
- [x] Connection status displayed on screen
- [x] Hot module reload works for both React and PixiJS code

## Build verification
- `npm run build` passes (tsc for shared+server, Vite for client)
- `npm run lint` passes (all workspaces)
- `npm run test` passes (all workspaces)
- Client typecheck (`tsc --noEmit`) passes

## Files changed
| File | Purpose |
|------|---------|
| `client/index.html` | HTML entry with PixiJS canvas + React root containers |
| `client/src/main.tsx` | React 18 createRoot entry point |
| `client/src/App.tsx` | Top-level component (PixiJS + React overlay) |
| `client/src/game/PixiApp.ts` | PixiJS Application init + starfield renderer |
| `client/src/network/client.ts` | Colyseus client setup |
| `client/src/components/ConnectionStatusBadge.tsx` | Connection status UI |
| `client/vite.config.ts` | Vite config (React plugin, proxy, port) |
| `client/tsconfig.json` | Updated for JSX, DOM libs, bundler mode |
| `eslint.config.js` | Per-workspace project configs |
| `package.json` | Root build includes Vite client build |
| `tsconfig.json` | Removed client from tsc --build references |
