### PR TITLE
feat: Multi-stage Dockerfile for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.git
+.gitignore
+.github
+.squad
+.vscode
+docs
+coverage
+*.md
+!package.json
+.env
+.env.*
+infra
+**/*.test.ts
+**/__tests__

--- a/.squad/agents/marathe/history.md
+++ b/.squad/agents/marathe/history.md
@@ -946,3 +946,4 @@ permissions:
 - The existing CI was already well-structured; this was an enhancement pass, not a rewrite
 
 **PR:** #57 → `dev`
+- 2026-03-18: Issue #11 — Multi-stage Dockerfile for production deployment. Two-stage node:22-slim build: stage 1 does full npm ci + npm run build (tsc + vite), stage 2 copies only built artifacts with production deps. HEALTHCHECK curls /health endpoint. .dockerignore excludes node_modules, .git, docs, coverage, tests. Docker build verified locally — container starts and /health returns 200. Image ~658MB (node:22-slim + all workspace production deps). Server does NOT yet serve client static files — follow-up needed for Express static middleware. PR #60 → dev.

--- a/.squad/decisions/inbox/marathe-dockerfile.md
+++ b/.squad/decisions/inbox/marathe-dockerfile.md
@@ -1,0 +1,25 @@
+# Dockerfile Production Image Strategy
+
+**Author:** Marathe (DevOps)
+**Date:** 2026-03-18
+**Issue:** #11
+**PR:** #60
+
+## Decision
+
+Multi-stage Dockerfile using `node:22-slim` (Debian-based, not Alpine) for both build and production stages. Production stage installs all workspace production deps via `npm ci --omit=dev` and copies built artifacts only.
+
+## Rationale
+
+- **node:22-slim over Alpine:** npm workspaces + native modules (e.g., @colyseus packages) are more reliable on Debian. Alpine's musl libc causes sporadic build failures with native addons.
+- **Full workspace production deps:** `npm ci --omit=dev` installs production deps for all workspaces (including client's react/pixi.js). This adds ~100MB but avoids fragile selective workspace installs. Acceptable tradeoff for CI reliability.
+- **curl for HEALTHCHECK:** Installed in production image (~5MB) since node:22-slim doesn't include curl/wget. Required for Dockerfile HEALTHCHECK and compatible with Azure Container Apps health probes.
+
+## Follow-up Required
+
+- **Server static file serving:** The server does not serve `client/dist/` as static files. A follow-up task must add Express static middleware so the production container can serve the client bundle. Without this, the client needs a separate deployment (e.g., CDN/nginx sidecar).
+
+## Impact
+
+- Compatible with existing deploy workflows (`deploy-uat.yml`, `deploy-prod.yml`) which build and push to ACR.
+- HEALTHCHECK aligns with Azure Container Apps liveness probe expectations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# ---- Stage 1: Build ----
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+# Copy workspace package manifests first for layer caching
+COPY package.json package-lock.json ./
+COPY shared/package.json shared/
+COPY server/package.json server/
+COPY client/package.json client/
+
+# Install all dependencies (including devDeps for build tooling)
+RUN npm ci
+
+# Copy source code
+COPY tsconfig.json ./
+COPY shared/ shared/
+COPY server/ server/
+COPY client/ client/
+
+# Build: tsc --build (shared + server) then vite build (client)
+RUN npm run build
+
+# ---- Stage 2: Production ----
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace package manifests
+COPY package.json package-lock.json ./
+COPY shared/package.json shared/
+COPY server/package.json server/
+COPY client/package.json client/
+
+# Install production dependencies only
+RUN npm ci --omit=dev
+
+# Copy built artifacts from build stage
+COPY --from=build /app/shared/dist/ shared/dist/
+COPY --from=build /app/server/dist/ server/dist/
+COPY --from=build /app/client/dist/ client/dist/
+
+ENV NODE_ENV=production
+EXPOSE 2567
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:2567/health || exit 1
+
+CMD ["node", "server/dist/index.js"]


### PR DESCRIPTION
## Summary
Adds a multi-stage Dockerfile and .dockerignore for production deployment.

Closes #11

## What's included
- **Stage 1 (build):** `node:22-slim`, installs all deps, runs `npm run build` (tsc + vite)
- **Stage 2 (production):** `node:22-slim`, production deps only, copies built artifacts
- **HEALTHCHECK:** `curl -f http://localhost:2567/health` (30s interval, 5s timeout, 10s start period)
- **.dockerignore:** Excludes node_modules, .git, docs, coverage, tests, .squad

## Verified
- `docker build -t void-market .` ✅ succeeds
- Container starts, `/health` returns `{"status":"ok"}` ✅
- Production image: ~658MB (node:22-slim base)
- `npm run build` ✅ no regressions
- `npm run lint` ✅ clean

## Follow-up needed
The server does not yet serve the client static files (no Express static middleware for `client/dist/`). A follow-up task should add `express.static` to serve the built client bundle in production.

## Acceptance Criteria
- [x] Multi-stage Dockerfile (build stage + production stage)
- [x] Builds all workspaces in build stage
- [x] Production image contains server + static client build
- [x] HEALTHCHECK instruction uses /health endpoint
- [x] Image size optimized (node:22-slim)
- [x] Compatible with existing CI/CD workflows
- [x] docker build succeeds and container runs correctly