### PR TITLE
feat(shared): Galaxy state schemas, game constants, message protocol (#13, #14, #15)

### DIFF
--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -821,3 +821,14 @@ Turn-based gameplay in real-time multiplayer framework = hybrid model where disc
 **Next Phase 1 Task:** Issue #13 (Shared schemas revision). Refine game state interfaces based on trading loop requirements before Phase 1 dev begins.
 
 **Orchestration Log:** `.squad/orchestration-log/2026-03-18T001000Z-wave{3,4}-*.md` for full details.
+
+## Learnings
+
+### 2026-03-18: Shared schemas, constants, and messages (#13, #14, #15)
+- **Schema directory structure:** Moved from single `schemas.ts` to `shared/src/schemas/` with one file per class. Keeps `schemas.ts` as backward-compatible re-export shim. Same pattern for messages → `shared/src/messages/`.
+- **Colyseus v4 compact types:** Used `uint16` for sector IDs and turn counts (max 65535, sufficient for 500 sectors and 2000 turn bank), `uint32` for stock/prices, `float64` for credits and timestamps, `float32` for coordinates. Saves significant bandwidth vs `"number"` (which defaults to float64).
+- **Port class as string code:** Chose `"SBB"` string notation over numeric PortClass enum for `PortSchema.portClass`. More readable, self-documenting, and maps directly to `PORT_CLASS_DEFS` constant. The numeric `PortClass` enum in enums.ts is preserved but the schema uses string codes.
+- **Nested ship schema:** `PlayerSchema.ship` is a nested `ShipSchema` rather than a reference. This gives Colyseus automatic delta sync on ship state changes without extra message plumbing.
+- **Env override pattern:** `envInt`/`envFloat` helpers with `typeof process === "undefined"` guard for browser safety. All env vars use `VM_` prefix to avoid collisions.
+- **Ship spec corrections:** Scout cargo = 25 (not 50), Merchant cargo = 100 (not 300), Merchant speed = 1 (slow, not 2). Aligned to team decisions doc.
+- **PR #64** → `dev` branch. Closes #13, #14, #15.

--- a/.squad/decisions/inbox/pemulis-shared-schemas.md
+++ b/.squad/decisions/inbox/pemulis-shared-schemas.md
@@ -1,0 +1,35 @@
+# Schema Design Decisions — Pemulis (#13, #14, #15)
+
+**Date:** 2026-03-18  
+**PR:** #64  
+**Status:** Proposed (in PR)
+
+## Decisions Made
+
+### 1. Port class uses string codes, not numeric enum
+**Choice:** `PortSchema.portClass` is a `string` ("SBB", "BSB", etc.) rather than numeric `PortClass` enum.  
+**Rationale:** Self-documenting, maps directly to `PORT_CLASS_DEFS`, easier to debug in network traces. The numeric `PortClass` enum remains in `enums.ts` for any code that needs it, but the schema wire format is string.
+
+### 2. Nested ShipSchema on PlayerSchema
+**Choice:** `PlayerSchema.ship` is a nested `ShipSchema` instance, not a separate MapSchema reference.  
+**Rationale:** Colyseus delta-syncs nested schemas automatically. This means ship state changes (cargo, holds) propagate to the client without extra message handling. Trade-off: each player always syncs their full ship state, but for MVP that's fine.
+
+### 3. Commodity tracking via MapSchema<CommoditySchema>
+**Choice:** `PortSchema.commodities` is `MapSchema<CommoditySchema>` keyed by commodity name string.  
+**Rationale:** More extensible than flat fields (stockFuelOre, etc.). When Exotic Matter is added in Phase 2+, just add a new key — no schema migration needed. Also gives per-commodity buy/sell price tracking that the old flat fields lacked.
+
+### 4. Sector playerIds as ArraySchema<string> vs nested players
+**Choice:** `SectorSchema.playerIds` stores string IDs, not nested `PlayerSchema`.  
+**Rationale:** Avoids double-syncing player data (already in `GalaxyState.players`). The sector just needs to know who's present for rendering, not their full state.
+
+### 5. Ship specs: Scout 25 holds / Merchant 100 holds
+**Choice:** Corrected from placeholder values (50/300) to decision-doc values (25/100).  
+**Rationale:** Scout = fast + light (25 holds, speed 3), Merchant = slow + heavy (100 holds, speed 1). This creates meaningful ship progression and trade-offs.
+
+### 6. Environment overrides with VM_ prefix
+**Choice:** Key balancing values (sector count, turn regen, starting credits, tick rates, etc.) are overridable via `VM_*` env vars.  
+**Rationale:** Allows tuning in staging/prod without code changes. Browser-safe: `typeof process === "undefined"` guard returns fallback on client.
+
+## Open Questions
+- Should `CommoditySchema.buyPrice`/`sellPrice` naming be from the **player's** perspective or the **port's** perspective? Currently named from player perspective (buyPrice = what player pays). Server team should confirm.
+- Port in `SectorSchema` is optional (`PortSchema | undefined`). Colyseus handles this, but we should verify delta sync behavior when port is null.

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -1,20 +1,41 @@
 /**
  * Game constants for Void Market.
  * Single source of truth for balancing values used by both client and server.
+ *
+ * Key values are overridable via environment variables (server-side).
+ * Use the envInt / envFloat helpers to read overrides with fallbacks.
  */
 
-import { ActionType, Commodity, ShipClass } from "./enums.js";
+import { ActionType, Commodity, PortTradeType, ShipClass } from "./enums.js";
+
+// ── Environment Helpers ──────────────────────────────────────────────────────
+
+function envInt(key: string, fallback: number): number {
+  if (typeof process === "undefined") return fallback;
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function envFloat(key: string, fallback: number): number {
+  if (typeof process === "undefined") return fallback;
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const parsed = parseFloat(raw);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
 
 // ── Turn System ──────────────────────────────────────────────────────────────
 
 /** Milliseconds between turn regeneration ticks. */
-export const TURN_REGEN_INTERVAL_MS = 90_000;
+export const TURN_REGEN_INTERVAL_MS = envInt("VM_TURN_REGEN_MS", 90_000);
 
 /** Maximum turns a player can bank. */
-export const MAX_TURN_BANK = 2_000;
+export const MAX_TURN_BANK = envInt("VM_MAX_TURN_BANK", 2_000);
 
 /** Starting turns for a new player. */
-export const STARTING_TURNS = 500;
+export const STARTING_TURNS = envInt("VM_STARTING_TURNS", 500);
 
 /** Turn cost per action type. */
 export const TURN_COSTS: Readonly<Record<ActionType, number>> = {
@@ -41,7 +62,7 @@ export const COMMODITIES = [
 ] as const;
 
 /** Starting credits for a new player. */
-export const STARTING_CREDITS = 10_000;
+export const STARTING_CREDITS = envInt("VM_STARTING_CREDITS", 10_000);
 
 /** Base price per commodity (used as anchor for dynamic pricing). */
 export const BASE_PRICES: Readonly<Record<Commodity, number>> = {
@@ -51,18 +72,115 @@ export const BASE_PRICES: Readonly<Record<Commodity, number>> = {
 };
 
 /** Maximum stock a port can hold per commodity. */
-export const MAX_PORT_STOCK = 5_000;
+export const MAX_PORT_STOCK = envInt("VM_MAX_PORT_STOCK", 5_000);
+
+/** Price fluctuation range (±percentage from base price based on stock). */
+export const PRICE_VARIANCE_PCT = envFloat("VM_PRICE_VARIANCE_PCT", 0.25);
+
+/** Units restocked per economy tick per commodity. */
+export const RESTOCK_RATE = envInt("VM_RESTOCK_RATE", 50);
+
+// ── Port Class Definitions ───────────────────────────────────────────────────
+
+/**
+ * Port class trading behavior per commodity.
+ * Code notation: S = port Sells to player, B = port Buys from player.
+ * Order: [Fuel Ore, Organics, Equipment]
+ */
+export interface PortClassDef {
+  /** Three-letter code: e.g. "SBB" */
+  readonly code: string;
+  /** Per-commodity trade direction. */
+  readonly trades: Readonly<Record<Commodity, PortTradeType>>;
+}
+
+/** All port class definitions keyed by code string. */
+export const PORT_CLASS_DEFS: Readonly<Record<string, PortClassDef>> = {
+  SBB: {
+    code: "SBB",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Selling,
+      [Commodity.Organics]: PortTradeType.Buying,
+      [Commodity.Equipment]: PortTradeType.Buying,
+    },
+  },
+  BSB: {
+    code: "BSB",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Buying,
+      [Commodity.Organics]: PortTradeType.Selling,
+      [Commodity.Equipment]: PortTradeType.Buying,
+    },
+  },
+  BBS: {
+    code: "BBS",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Buying,
+      [Commodity.Organics]: PortTradeType.Buying,
+      [Commodity.Equipment]: PortTradeType.Selling,
+    },
+  },
+  SSB: {
+    code: "SSB",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Selling,
+      [Commodity.Organics]: PortTradeType.Selling,
+      [Commodity.Equipment]: PortTradeType.Buying,
+    },
+  },
+  SBS: {
+    code: "SBS",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Selling,
+      [Commodity.Organics]: PortTradeType.Buying,
+      [Commodity.Equipment]: PortTradeType.Selling,
+    },
+  },
+  BSS: {
+    code: "BSS",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Buying,
+      [Commodity.Organics]: PortTradeType.Selling,
+      [Commodity.Equipment]: PortTradeType.Selling,
+    },
+  },
+  BBB: {
+    code: "BBB",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Buying,
+      [Commodity.Organics]: PortTradeType.Buying,
+      [Commodity.Equipment]: PortTradeType.Buying,
+    },
+  },
+  SSS: {
+    code: "SSS",
+    trades: {
+      [Commodity.FuelOre]: PortTradeType.Selling,
+      [Commodity.Organics]: PortTradeType.Selling,
+      [Commodity.Equipment]: PortTradeType.Selling,
+    },
+  },
+};
+
+/** Valid port class codes. */
+export const PORT_CLASS_CODES = Object.keys(PORT_CLASS_DEFS) as readonly string[];
 
 // ── Galaxy ───────────────────────────────────────────────────────────────────
 
 /** Default number of sectors in a generated galaxy. */
-export const DEFAULT_SECTOR_COUNT = 500;
+export const DEFAULT_SECTOR_COUNT = envInt("VM_SECTOR_COUNT", 500);
+
+/** Minimum warp connections per sector. */
+export const MIN_WARPS_PER_SECTOR = 2;
 
 /** Maximum warp connections per sector. */
 export const MAX_WARPS_PER_SECTOR = 6;
 
 /** Sector ID of the starting sector (Federation HQ / safe zone). */
 export const STARTING_SECTOR_ID = 1;
+
+/** Percentage of sectors that contain a port (0.0–1.0). */
+export const PORT_DENSITY = envFloat("VM_PORT_DENSITY", 0.6);
 
 // ── Ships ────────────────────────────────────────────────────────────────────
 
@@ -77,17 +195,17 @@ export interface ShipSpec {
 /** Base ship specifications per class. */
 export const SHIP_SPECS: Readonly<Record<ShipClass, ShipSpec>> = {
   [ShipClass.Scout]: {
-    cargoCapacity: 50,
+    cargoCapacity: 25,
     maxShields: 100,
     maxFighters: 0,
     warpSpeed: 3,
     cost: 0,
   },
   [ShipClass.Merchant]: {
-    cargoCapacity: 300,
+    cargoCapacity: 100,
     maxShields: 200,
     maxFighters: 50,
-    warpSpeed: 2,
+    warpSpeed: 1,
     cost: 50_000,
   },
   [ShipClass.Frigate]: {
@@ -116,10 +234,10 @@ export const SHIP_SPECS: Readonly<Record<ShipClass, ShipSpec>> = {
 // ── Server Tick Rates ────────────────────────────────────────────────────────
 
 /** Fast tick interval (player actions, movement). */
-export const FAST_TICK_MS = 1_000;
+export const FAST_TICK_MS = envInt("VM_FAST_TICK_MS", 1_000);
 
 /** Slow tick interval (economy restock, NPC actions). */
-export const SLOW_TICK_MS = 60_000;
+export const SLOW_TICK_MS = envInt("VM_SLOW_TICK_MS", 60_000);
 
 // ── Federation / Alliance ────────────────────────────────────────────────────
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -23,9 +23,15 @@ export {
   STARTING_CREDITS,
   BASE_PRICES,
   MAX_PORT_STOCK,
+  PRICE_VARIANCE_PCT,
+  RESTOCK_RATE,
+  PORT_CLASS_DEFS,
+  PORT_CLASS_CODES,
   DEFAULT_SECTOR_COUNT,
+  MIN_WARPS_PER_SECTOR,
   MAX_WARPS_PER_SECTOR,
   STARTING_SECTOR_ID,
+  PORT_DENSITY,
   SHIP_SPECS,
   FAST_TICK_MS,
   SLOW_TICK_MS,
@@ -36,7 +42,7 @@ export {
   WAR_DECLARATION_COST,
   MIN_WAR_DURATION_MS,
 } from "./constants.js";
-export type { ShipSpec } from "./constants.js";
+export type { ShipSpec, PortClassDef } from "./constants.js";
 
 // Types (pure interfaces — no runtime)
 export type {
@@ -58,9 +64,36 @@ export type {
 
 // Colyseus Schema classes
 export {
-  PlayerSchema,
+  CargoSchema,
+  CommoditySchema,
   ShipSchema,
   PortSchema,
+  PlayerSchema,
   SectorSchema,
   GalaxyState,
-} from "./schemas.js";
+} from "./schemas/index.js";
+
+// Message protocol types
+export {
+  CLIENT_MSG,
+  SERVER_MSG,
+} from "./messages/index.js";
+export type {
+  ClientMessageType,
+  MoveMessage,
+  TradeMessage,
+  DockMessage,
+  UndockMessage,
+  SectorScanMessage,
+  PortQueryMessage,
+  ClientMessage,
+  ServerMessageType,
+  ErrorMessage,
+  TradeResultMessage,
+  SystemMessage,
+  PlayerJoinedMessage,
+  PlayerLeftMessage,
+  SectorEnteredMessage,
+  TurnUpdateMessage,
+  ServerMessage,
+} from "./messages/index.js";

--- a/shared/src/messages/ClientMessages.ts
+++ b/shared/src/messages/ClientMessages.ts
@@ -1,0 +1,68 @@
+/**
+ * Client → Server message types.
+ * Sent from client to server via Colyseus room.send().
+ * Uses discriminated union pattern with `type` field.
+ */
+
+// ── Message Type Constants ───────────────────────────────────────────────────
+
+export const CLIENT_MSG = {
+  MOVE: "move",
+  TRADE: "trade",
+  DOCK: "dock",
+  UNDOCK: "undock",
+  SECTOR_SCAN: "sector_scan",
+  PORT_QUERY: "port_query",
+} as const;
+
+export type ClientMessageType = (typeof CLIENT_MSG)[keyof typeof CLIENT_MSG];
+
+// ── Message Payloads ─────────────────────────────────────────────────────────
+
+/** Request to move to an adjacent sector via warp connection. */
+export interface MoveMessage {
+  readonly type: typeof CLIENT_MSG.MOVE;
+  readonly targetSectorId: number;
+}
+
+/** Request to execute a trade at the currently docked port. */
+export interface TradeMessage {
+  readonly type: typeof CLIENT_MSG.TRADE;
+  readonly commodity: string;
+  readonly quantity: number;
+  /** True = player buys from port; false = player sells to port. */
+  readonly buying: boolean;
+}
+
+/** Request to dock at the port in the player's current sector. */
+export interface DockMessage {
+  readonly type: typeof CLIENT_MSG.DOCK;
+}
+
+/** Request to undock from the current port. */
+export interface UndockMessage {
+  readonly type: typeof CLIENT_MSG.UNDOCK;
+}
+
+/** Request sector scan information. */
+export interface SectorScanMessage {
+  readonly type: typeof CLIENT_MSG.SECTOR_SCAN;
+  readonly sectorId: number;
+}
+
+/** Request port commodity details. */
+export interface PortQueryMessage {
+  readonly type: typeof CLIENT_MSG.PORT_QUERY;
+  readonly portId: string;
+}
+
+// ── Discriminated Union ──────────────────────────────────────────────────────
+
+/** Union of all client→server messages. */
+export type ClientMessage =
+  | MoveMessage
+  | TradeMessage
+  | DockMessage
+  | UndockMessage
+  | SectorScanMessage
+  | PortQueryMessage;

--- a/shared/src/messages/ServerMessages.ts
+++ b/shared/src/messages/ServerMessages.ts
@@ -1,0 +1,91 @@
+/**
+ * Server → Client message types.
+ * Sent from server to client via Colyseus room.send() or broadcast().
+ * Uses discriminated union pattern with `type` field.
+ */
+
+// ── Message Type Constants ───────────────────────────────────────────────────
+
+export const SERVER_MSG = {
+  ERROR: "error",
+  TRADE_RESULT: "trade_result",
+  SYSTEM: "system",
+  PLAYER_JOINED: "player_joined",
+  PLAYER_LEFT: "player_left",
+  SECTOR_ENTERED: "sector_entered",
+  TURN_UPDATE: "turn_update",
+} as const;
+
+export type ServerMessageType = (typeof SERVER_MSG)[keyof typeof SERVER_MSG];
+
+// ── Message Payloads ─────────────────────────────────────────────────────────
+
+/** Error response from server. */
+export interface ErrorMessage {
+  readonly type: typeof SERVER_MSG.ERROR;
+  readonly code: string;
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+}
+
+/** Result of a completed trade transaction. */
+export interface TradeResultMessage {
+  readonly type: typeof SERVER_MSG.TRADE_RESULT;
+  readonly success: boolean;
+  readonly commodity: string;
+  readonly quantity: number;
+  readonly totalPrice: number;
+  readonly newCredits: number;
+  readonly newStock: number;
+  readonly error?: string;
+}
+
+/** System broadcast (server announcements, maintenance, etc.). */
+export interface SystemMessage {
+  readonly type: typeof SERVER_MSG.SYSTEM;
+  readonly message: string;
+  readonly severity: "info" | "warning" | "critical";
+  readonly timestamp: number;
+}
+
+/** Notification that a player has joined the galaxy. */
+export interface PlayerJoinedMessage {
+  readonly type: typeof SERVER_MSG.PLAYER_JOINED;
+  readonly playerId: string;
+  readonly displayName: string;
+  readonly sectorId: number;
+}
+
+/** Notification that a player has left the galaxy. */
+export interface PlayerLeftMessage {
+  readonly type: typeof SERVER_MSG.PLAYER_LEFT;
+  readonly playerId: string;
+}
+
+/** Notification that a player entered the current sector. */
+export interface SectorEnteredMessage {
+  readonly type: typeof SERVER_MSG.SECTOR_ENTERED;
+  readonly playerId: string;
+  readonly displayName: string;
+  readonly sectorId: number;
+}
+
+/** Turn balance update pushed after any turn-consuming action. */
+export interface TurnUpdateMessage {
+  readonly type: typeof SERVER_MSG.TURN_UPDATE;
+  readonly turnsRemaining: number;
+  readonly turnsMax: number;
+  readonly nextRegenAt: number;
+}
+
+// ── Discriminated Union ──────────────────────────────────────────────────────
+
+/** Union of all server→client messages. */
+export type ServerMessage =
+  | ErrorMessage
+  | TradeResultMessage
+  | SystemMessage
+  | PlayerJoinedMessage
+  | PlayerLeftMessage
+  | SectorEnteredMessage
+  | TurnUpdateMessage;

--- a/shared/src/messages/index.ts
+++ b/shared/src/messages/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Message protocol barrel export.
+ * All client↔server message types for Colyseus room communication.
+ */
+
+// Client → Server
+export {
+  CLIENT_MSG,
+  type ClientMessageType,
+  type MoveMessage,
+  type TradeMessage,
+  type DockMessage,
+  type UndockMessage,
+  type SectorScanMessage,
+  type PortQueryMessage,
+  type ClientMessage,
+} from "./ClientMessages.js";
+
+// Server → Client
+export {
+  SERVER_MSG,
+  type ServerMessageType,
+  type ErrorMessage,
+  type TradeResultMessage,
+  type SystemMessage,
+  type PlayerJoinedMessage,
+  type PlayerLeftMessage,
+  type SectorEnteredMessage,
+  type TurnUpdateMessage,
+  type ServerMessage,
+} from "./ServerMessages.js";

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -1,66 +1,16 @@
 /**
  * Colyseus Schema base classes for Void Market.
  *
- * These are minimal scaffolds that prove the decorator pattern works.
- * They will be fleshed out as game systems are implemented in Phase 1.
- *
- * Schema classes are the authoritative state objects synchronized
- * from server → client via Colyseus delta compression.
+ * Re-exports from shared/src/schemas/ for backward compatibility.
+ * New code should import directly from "./schemas/index.js".
  */
 
-import { Schema, type, MapSchema, ArraySchema } from "@colyseus/schema";
-
-// ── Player ───────────────────────────────────────────────────────────────────
-
-export class PlayerSchema extends Schema {
-  @type("string") playerId: string = "";
-  @type("string") displayName: string = "";
-  @type("number") sectorId: number = 1;
-  @type("number") credits: number = 0;
-  @type("number") turnsRemaining: number = 0;
-  @type("string") shipClass: string = "scout";
-}
-
-// ── Ship ─────────────────────────────────────────────────────────────────────
-
-export class ShipSchema extends Schema {
-  @type("string") shipId: string = "";
-  @type("string") shipClass: string = "scout";
-  @type("string") name: string = "";
-  @type("number") shields: number = 0;
-  @type("number") fighters: number = 0;
-  @type("number") cargoFuelOre: number = 0;
-  @type("number") cargoOrganics: number = 0;
-  @type("number") cargoEquipment: number = 0;
-}
-
-// ── Port ─────────────────────────────────────────────────────────────────────
-
-export class PortSchema extends Schema {
-  @type("string") portId: string = "";
-  @type("string") name: string = "";
-  @type("number") sectorId: number = 0;
-  @type("uint8") portClass: number = 1;
-  @type("number") stockFuelOre: number = 0;
-  @type("number") stockOrganics: number = 0;
-  @type("number") stockEquipment: number = 0;
-}
-
-// ── Sector ───────────────────────────────────────────────────────────────────
-
-export class SectorSchema extends Schema {
-  @type("number") sectorId: number = 0;
-  @type("number") x: number = 0;
-  @type("number") y: number = 0;
-  @type("boolean") hasPort: boolean = false;
-  @type([PlayerSchema]) players = new ArraySchema<PlayerSchema>();
-}
-
-// ── Galaxy State (GalaxyRoom root state) ─────────────────────────────────────
-
-export class GalaxyState extends Schema {
-  @type({ map: SectorSchema }) sectors = new MapSchema<SectorSchema>();
-  @type({ map: PlayerSchema }) players = new MapSchema<PlayerSchema>();
-  @type({ map: PortSchema }) ports = new MapSchema<PortSchema>();
-  @type("number") tickCount: number = 0;
-}
+export {
+  CargoSchema,
+  CommoditySchema,
+  ShipSchema,
+  PortSchema,
+  PlayerSchema,
+  SectorSchema,
+  GalaxyState,
+} from "./schemas/index.js";

--- a/shared/src/schemas/CargoSchema.ts
+++ b/shared/src/schemas/CargoSchema.ts
@@ -1,0 +1,10 @@
+import { Schema, type } from "@colyseus/schema";
+
+/**
+ * A single cargo slot in a ship's hold.
+ * Tracks commodity type and quantity carried.
+ */
+export class CargoSchema extends Schema {
+  @type("string") commodity: string = "";
+  @type("uint32") quantity: number = 0;
+}

--- a/shared/src/schemas/CommoditySchema.ts
+++ b/shared/src/schemas/CommoditySchema.ts
@@ -1,0 +1,25 @@
+import { Schema, type } from "@colyseus/schema";
+
+/**
+ * A commodity listing at a port.
+ * Tracks stock levels and current buy/sell prices.
+ */
+export class CommoditySchema extends Schema {
+  /** Commodity identifier (matches Commodity enum value). */
+  @type("string") commodity: string = "";
+
+  /** Current stock at this port. */
+  @type("uint32") stock: number = 0;
+
+  /** Maximum stock this port can hold for this commodity. */
+  @type("uint32") maxStock: number = 0;
+
+  /** Price the port charges when selling to players. 0 if port doesn't sell. */
+  @type("uint32") buyPrice: number = 0;
+
+  /** Price the port pays when buying from players. 0 if port doesn't buy. */
+  @type("uint32") sellPrice: number = 0;
+
+  /** Whether the port is buying (true) or selling (false) this commodity. */
+  @type("boolean") portBuys: boolean = false;
+}

--- a/shared/src/schemas/GalaxyState.ts
+++ b/shared/src/schemas/GalaxyState.ts
@@ -1,0 +1,22 @@
+import { Schema, type, MapSchema } from "@colyseus/schema";
+import { SectorSchema } from "./SectorSchema.js";
+import { PlayerSchema } from "./PlayerSchema.js";
+
+/**
+ * Root state schema for GalaxyRoom.
+ * This is the top-level Colyseus state object — all synchronized
+ * game state hangs off this tree.
+ */
+export class GalaxyState extends Schema {
+  /** All sectors keyed by sector ID string. */
+  @type({ map: SectorSchema }) sectors = new MapSchema<SectorSchema>();
+
+  /** All online players keyed by player ID. */
+  @type({ map: PlayerSchema }) players = new MapSchema<PlayerSchema>();
+
+  /** Server tick counter (increments each fast tick). */
+  @type("uint32") tickCount: number = 0;
+
+  /** Server timestamp of last economy tick. */
+  @type("float64") lastEconomyTick: number = 0;
+}

--- a/shared/src/schemas/PlayerSchema.ts
+++ b/shared/src/schemas/PlayerSchema.ts
@@ -1,0 +1,32 @@
+import { Schema, type } from "@colyseus/schema";
+import { ShipSchema } from "./ShipSchema.js";
+
+/**
+ * Player state synchronized via Colyseus delta patching.
+ * MVP fields only — no alliance/federation membership until Phase 2+.
+ */
+export class PlayerSchema extends Schema {
+  @type("string") playerId: string = "";
+  @type("string") displayName: string = "";
+
+  /** Current credits balance. */
+  @type("float64") credits: number = 0;
+
+  /** Turns remaining in the player's bank. */
+  @type("uint16") turnsRemaining: number = 0;
+
+  /** Maximum turn bank capacity. */
+  @type("uint16") turnsMax: number = 2000;
+
+  /** Sector the player currently occupies. */
+  @type("uint16") currentSectorId: number = 1;
+
+  /** Whether the player is currently docked at a port. */
+  @type("boolean") isDocked: boolean = false;
+
+  /** Whether the player is currently online. */
+  @type("boolean") isOnline: boolean = false;
+
+  /** The player's ship (nested schema for delta sync). */
+  @type(ShipSchema) ship: ShipSchema = new ShipSchema();
+}

--- a/shared/src/schemas/PortSchema.ts
+++ b/shared/src/schemas/PortSchema.ts
@@ -1,0 +1,21 @@
+import { Schema, type, MapSchema } from "@colyseus/schema";
+import { CommoditySchema } from "./CommoditySchema.js";
+
+/**
+ * Port state synchronized via Colyseus delta patching.
+ * Each port belongs to a sector and trades commodities based on its class.
+ */
+export class PortSchema extends Schema {
+  @type("string") portId: string = "";
+  @type("string") name: string = "";
+  @type("uint16") sectorId: number = 0;
+
+  /** Port class code string: e.g. "SBB", "BSB" (S=sells, B=buys for Fuel/Org/Equip). */
+  @type("string") portClass: string = "BBS";
+
+  /** Commodity listings keyed by commodity name (fuel_ore, organics, equipment). */
+  @type({ map: CommoditySchema }) commodities = new MapSchema<CommoditySchema>();
+
+  /** Timestamp of last economy restock tick. */
+  @type("float64") lastRestock: number = 0;
+}

--- a/shared/src/schemas/SectorSchema.ts
+++ b/shared/src/schemas/SectorSchema.ts
@@ -1,0 +1,25 @@
+import { Schema, type, ArraySchema } from "@colyseus/schema";
+import { PortSchema } from "./PortSchema.js";
+
+/**
+ * Sector state synchronized via Colyseus delta patching.
+ * Each sector is a node in the galaxy graph with warp connections.
+ */
+export class SectorSchema extends Schema {
+  @type("uint16") sectorId: number = 0;
+
+  /** X coordinate for galaxy map rendering. */
+  @type("float32") x: number = 0;
+
+  /** Y coordinate for galaxy map rendering. */
+  @type("float32") y: number = 0;
+
+  /** Warp connections — sector IDs reachable from here. */
+  @type(["uint16"]) warps = new ArraySchema<number>();
+
+  /** Port in this sector (null if no port). */
+  @type(PortSchema) port: PortSchema | undefined;
+
+  /** Player IDs currently in this sector. */
+  @type(["string"]) playerIds = new ArraySchema<string>();
+}

--- a/shared/src/schemas/ShipSchema.ts
+++ b/shared/src/schemas/ShipSchema.ts
@@ -1,0 +1,24 @@
+import { Schema, type, ArraySchema } from "@colyseus/schema";
+import { CargoSchema } from "./CargoSchema.js";
+
+/**
+ * Ship state synchronized via Colyseus delta patching.
+ * MVP fields only — no combat stats (shields, fighters) until Phase 2.
+ */
+export class ShipSchema extends Schema {
+  @type("string") shipId: string = "";
+  @type("string") shipClass: string = "scout";
+  @type("string") name: string = "";
+
+  /** Current number of filled cargo holds. */
+  @type("uint16") cargoHolds: number = 0;
+
+  /** Maximum cargo hold capacity for this ship class. */
+  @type("uint16") maxCargoHolds: number = 25;
+
+  /** Warp speed (sectors per turn). */
+  @type("uint8") speed: number = 3;
+
+  /** Cargo manifest — one entry per commodity type carried. */
+  @type([CargoSchema]) cargo = new ArraySchema<CargoSchema>();
+}

--- a/shared/src/schemas/index.ts
+++ b/shared/src/schemas/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Colyseus Schema barrel export.
+ * All schema classes used for server↔client state synchronization.
+ */
+export { CargoSchema } from "./CargoSchema.js";
+export { CommoditySchema } from "./CommoditySchema.js";
+export { ShipSchema } from "./ShipSchema.js";
+export { PortSchema } from "./PortSchema.js";
+export { PlayerSchema } from "./PlayerSchema.js";
+export { SectorSchema } from "./SectorSchema.js";
+export { GalaxyState } from "./GalaxyState.js";


### PR DESCRIPTION
## Summary

Implements the shared contract layer for Void Market — the foundation that both server and client depend on.

### Issue #13 — Galaxy state Colyseus schemas
- 7 Schema classes in `shared/src/schemas/`: GalaxyState, SectorSchema, PlayerSchema, ShipSchema, PortSchema, CargoSchema, CommoditySchema
- All fields use compact Colyseus types (`uint16`, `uint32`, `float32`, `float64`) for efficient delta sync
- GalaxyState root with `MapSchema<SectorSchema>` and `MapSchema<PlayerSchema>`
- PlayerSchema has nested `ShipSchema` for direct delta sync of ship state
- PortSchema uses `MapSchema<CommoditySchema>` for per-commodity stock/price tracking
- MVP-only: no combat, planet, or federation fields

### Issue #14 — Shared constants and game configuration
- Port class definitions: SBB, BSB, BBS, SSB, SBS, BSS, BBB, SSS with per-commodity trade directions
- Ship specs: Scout (25 holds, speed 3), Merchant (100 holds, speed 1) per team decisions
- New constants: `PRICE_VARIANCE_PCT`, `RESTOCK_RATE`, `MIN_WARPS_PER_SECTOR`, `PORT_DENSITY`
- Key values overridable via `VM_*` environment variables with browser-safe fallbacks

### Issue #15 — Message protocol types
- Client→server: MoveMessage, TradeMessage, DockMessage, UndockMessage, SectorScanMessage, PortQueryMessage
- Server→client: ErrorMessage, TradeResultMessage, SystemMessage, PlayerJoinedMessage, PlayerLeftMessage, SectorEnteredMessage, TurnUpdateMessage
- Discriminated union pattern with `CLIENT_MSG` / `SERVER_MSG` string literal constants
- Full barrel export from `shared/`

## Testing
- `npm run build` ✅ (all .js + .d.ts emitted in shared/dist/)
- `npm run lint` ✅
- `npm run test` ✅ (12 tests pass)

Closes #13, closes #14, closes #15