### PR TITLE
feat(client): Galaxy map PixiJS renderer (#29)

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -35,6 +35,15 @@
 
 ## Learnings
 
+### 2026-03-17: PR #68 — Galaxy Map PixiJS Renderer (#29)
+
+- **GalaxyRenderer** is fully data-driven — accepts `GalaxyData` (plain interfaces mirroring Colyseus schemas), renders sectors as `SectorNode` instances and warp connections as batched `Graphics` lines.
+- **pixi-viewport** works with PixiJS 8 for drag-pan and scroll-zoom. Key config: `clampZoom` for limits, `decelerate` for smooth stop, `wheel({ smooth: 5 })` for smooth zoom.
+- **Import paths:** Shared package only exports from barrel (`@void-market/shared`), not subpaths.
+- **ESLint strictness:** Arrow wrappers needed for event handlers; template literals needed for string concatenation with numbers.
+- **Container culling:** `cullable = true` on parent and children skips render calls for off-screen nodes.
+- **Mock data:** Seeded RNG ensures deterministic placement. Nearest-neighbor warp topology. ~40% port density.
+
 ### 2026-03-16: PR #122 Final Approval — Head-to-Head Mode Merged
 
 - **Decisions merged:** `gately-head-to-head.md` and `gately-turn-indicator.md` now in `.squad/decisions.md`

--- a/.squad/decisions/inbox/gately-galaxy-renderer.md
+++ b/.squad/decisions/inbox/gately-galaxy-renderer.md
@@ -1,0 +1,20 @@
+# Decision: Galaxy Map Renderer Architecture
+
+**Date:** 2026-03-17  
+**Author:** Gately (Game Dev)  
+**PR:** #68  
+**Issue:** #29
+
+## Decisions
+
+1. **Data-driven renderer with plain interfaces** — `GalaxyRenderer` accepts `GalaxyData` (plain TS interfaces), not Colyseus Schema objects. Decouples rendering from networking.
+2. **pixi-viewport for camera** — Drag, pinch, wheel zoom, decelerate, clamp-zoom. Zoom range 0.05x–3x, initial 0.15x centered on starting sector.
+3. **Single Graphics batch for warp lines** — All warp connections in one `Graphics` object. Edge deduplication via key set.
+4. **Colors from design tokens** — No hardcoded hex. Sector color encodes state (neutral=empty, resource hue=port, warning=occupied, primary=current).
+5. **Mock data is temporary** — `mockGalaxyData.ts` replaced by Colyseus state sync (issue #31). Seeded RNG for determinism.
+
+## Consequences
+
+- Client can iterate on galaxy visuals without a running server
+- Colyseus integration (#31) needs a mapper from `GalaxyState` schema to `GalaxyData`
+- New visual states just extend `SectorNode.draw()`

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "clsx": "^2.1.0",
     "colyseus.js": "^0.16.0",
     "lucide-react": "^0.487.0",
+    "pixi-viewport": "^6.0.3",
     "pixi.js": "^8.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/client/src/game/GalaxyRenderer.ts
+++ b/client/src/game/GalaxyRenderer.ts
@@ -1,0 +1,153 @@
+/**
+ * GalaxyRenderer — data-driven galaxy map renderer.
+ * Accepts GalaxyData, renders sectors as interactive nodes and
+ * warp connections as lines. Designed for 60 FPS at 500 sectors
+ * using container culling.
+ */
+import { Container, Graphics } from "pixi.js";
+import { Canvas, Alpha } from "@void-market/shared";
+import { SectorNode, type SectorClickHandler } from "./SectorNode.js";
+import type { GalaxyData, SectorData } from "./mockGalaxyData.js";
+
+export class GalaxyRenderer extends Container {
+  private warpGraphics: Graphics;
+  private sectorNodes = new Map<number, SectorNode>();
+  private galaxyData: GalaxyData | undefined;
+  private onSectorClick: SectorClickHandler | undefined;
+
+  constructor(onSectorClick?: SectorClickHandler) {
+    super();
+    this.onSectorClick = onSectorClick;
+
+    // Warp lines layer (drawn behind sector nodes)
+    this.warpGraphics = new Graphics();
+    this.addChild(this.warpGraphics);
+
+    // Enable culling so off-screen children skip rendering
+    this.cullable = true;
+    this.cullableChildren = true;
+  }
+
+  /** Render or re-render the full galaxy from data. */
+  setGalaxyData(data: GalaxyData): void {
+    this.galaxyData = data;
+    this.rebuildAll();
+  }
+
+  /** Full rebuild — clears and redraws everything. */
+  private rebuildAll(): void {
+    if (!this.galaxyData) return;
+
+    // Clear existing sector nodes
+    for (const node of this.sectorNodes.values()) {
+      node.destroy({ children: true });
+    }
+    this.sectorNodes.clear();
+
+    // Draw warp connections
+    this.drawWarps(this.galaxyData.sectors);
+
+    // Create sector nodes
+    for (const sector of this.galaxyData.sectors.values()) {
+      this.addSectorNode(sector);
+    }
+  }
+
+  private drawWarps(sectors: Map<number, SectorData>): void {
+    this.warpGraphics.clear();
+
+    // Track drawn edges to avoid duplicate lines
+    const drawn = new Set<string>();
+
+    for (const sector of sectors.values()) {
+      for (const targetId of sector.warps) {
+        const edgeKey = `${Math.min(sector.sectorId, targetId)}-${Math.max(sector.sectorId, targetId)}`;
+        if (drawn.has(edgeKey)) continue;
+        drawn.add(edgeKey);
+
+        const target = sectors.get(targetId);
+        if (!target) continue;
+
+        this.warpGraphics.moveTo(sector.x, sector.y);
+        this.warpGraphics.lineTo(target.x, target.y);
+      }
+    }
+
+    this.warpGraphics.stroke({
+      color: Canvas.warpRoute,
+      width: 1,
+      alpha: Alpha.warpRoute,
+    });
+  }
+
+  private addSectorNode(sector: SectorData): void {
+    if (!this.galaxyData) return;
+
+    const isCurrent = sector.sectorId === this.galaxyData.currentSectorId;
+    const hasLocalPlayer = sector.playerIds.includes(
+      this.galaxyData.currentPlayerId,
+    );
+
+    const node = new SectorNode(
+      sector,
+      isCurrent,
+      hasLocalPlayer,
+      this.onSectorClick,
+    );
+    node.cullable = true;
+    this.sectorNodes.set(sector.sectorId, node);
+    this.addChild(node);
+  }
+
+  /** Update a single sector in-place (for Colyseus delta updates). */
+  updateSector(sector: SectorData): void {
+    if (!this.galaxyData) return;
+
+    const existing = this.sectorNodes.get(sector.sectorId);
+    if (existing) {
+      const isCurrent = sector.sectorId === this.galaxyData.currentSectorId;
+      const hasLocalPlayer = sector.playerIds.includes(
+        this.galaxyData.currentPlayerId,
+      );
+      existing.update(sector, isCurrent, hasLocalPlayer);
+    }
+  }
+
+  /** Update which sector is the current player's location. */
+  setCurrentSector(sectorId: number): void {
+    if (!this.galaxyData) return;
+    const prevId = this.galaxyData.currentSectorId;
+    this.galaxyData.currentSectorId = sectorId;
+
+    // Refresh old and new current sector nodes
+    const prevSector = this.galaxyData.sectors.get(prevId);
+    const newSector = this.galaxyData.sectors.get(sectorId);
+    if (prevSector) this.updateSector(prevSector);
+    if (newSector) this.updateSector(newSector);
+  }
+
+  /** Get the bounds extent of the galaxy (for viewport sizing). */
+  getGalaxyExtent(): { minX: number; maxX: number; minY: number; maxY: number } {
+    if (!this.galaxyData) return { minX: 0, maxX: 0, minY: 0, maxY: 0 };
+
+    let minX = Infinity,
+      maxX = -Infinity,
+      minY = Infinity,
+      maxY = -Infinity;
+
+    for (const s of this.galaxyData.sectors.values()) {
+      if (s.x < minX) minX = s.x;
+      if (s.x > maxX) maxX = s.x;
+      if (s.y < minY) minY = s.y;
+      if (s.y > maxY) maxY = s.y;
+    }
+
+    const padding = 200;
+    return {
+      minX: minX - padding,
+      maxX: maxX + padding,
+      minY: minY - padding,
+      maxY: maxY + padding,
+    };
+  }
+}

--- a/client/src/game/GalaxyViewport.ts
+++ b/client/src/game/GalaxyViewport.ts
@@ -1,0 +1,60 @@
+/**
+ * GalaxyViewport — pixi-viewport wrapper for galaxy map camera.
+ * Provides drag-to-pan, scroll-to-zoom, zoom limits, and
+ * smooth zoom animation.
+ */
+import { Application } from "pixi.js";
+import { Viewport } from "pixi-viewport";
+
+const MIN_ZOOM = 0.05;
+const MAX_ZOOM = 3;
+const INITIAL_ZOOM = 0.15;
+
+export interface ViewportOptions {
+  /** World width in pixels (galaxy extent). */
+  worldWidth: number;
+  /** World height in pixels (galaxy extent). */
+  worldHeight: number;
+  /** Initial center x coordinate. */
+  centerX?: number;
+  /** Initial center y coordinate. */
+  centerY?: number;
+}
+
+export function createGalaxyViewport(
+  app: Application,
+  options: ViewportOptions,
+): Viewport {
+  const viewport = new Viewport({
+    screenWidth: app.screen.width,
+    screenHeight: app.screen.height,
+    worldWidth: options.worldWidth,
+    worldHeight: options.worldHeight,
+    events: app.renderer.events,
+  });
+
+  viewport
+    .drag()
+    .pinch()
+    .wheel({ smooth: 5 })
+    .decelerate({ friction: 0.92 })
+    .clampZoom({ minScale: MIN_ZOOM, maxScale: MAX_ZOOM });
+
+  // Set initial zoom and center
+  viewport.setZoom(INITIAL_ZOOM, true);
+
+  const cx = options.centerX ?? 0;
+  const cy = options.centerY ?? 0;
+  viewport.moveCenter(cx, cy);
+
+  return viewport;
+}
+
+/** Update viewport screen size on container resize. */
+export function resizeViewport(
+  viewport: Viewport,
+  width: number,
+  height: number,
+): void {
+  viewport.resize(width, height);
+}

--- a/client/src/game/PixiApp.ts
+++ b/client/src/game/PixiApp.ts
@@ -1,29 +1,22 @@
-import { Application, Graphics } from "pixi.js";
+/**
+ * PixiApp — application entry point.
+ * Initializes PixiJS 8, galaxy viewport, and the data-driven
+ * galaxy renderer. Currently uses mock data (replaced by Colyseus
+ * state sync in issue #31).
+ */
+import { Application } from "pixi.js";
+import { Canvas } from "@void-market/shared";
+import { GalaxyRenderer } from "./GalaxyRenderer.js";
+import { createGalaxyViewport, resizeViewport } from "./GalaxyViewport.js";
+import { generateMockGalaxy } from "./mockGalaxyData.js";
 
-const STAR_COUNT = 200;
-const BG_COLOR = 0x09090b; // zinc-950
-
-interface Star {
-  x: number;
-  y: number;
-  radius: number;
-  alpha: number;
-}
-
-function generateStars(width: number, height: number): Star[] {
-  return Array.from({ length: STAR_COUNT }, () => ({
-    x: Math.random() * width,
-    y: Math.random() * height,
-    radius: Math.random() * 1.5 + 0.5,
-    alpha: Math.random() * 0.7 + 0.3,
-  }));
-}
-
-export async function initPixiApp(container: HTMLElement): Promise<Application> {
+export async function initPixiApp(
+  container: HTMLElement,
+): Promise<Application> {
   const app = new Application();
 
   await app.init({
-    background: BG_COLOR,
+    background: Canvas.background,
     resizeTo: container,
     antialias: true,
     resolution: window.devicePixelRatio || 1,
@@ -32,30 +25,41 @@ export async function initPixiApp(container: HTMLElement): Promise<Application> 
 
   container.appendChild(app.canvas);
 
-  const stars = generateStars(app.screen.width, app.screen.height);
-  const starGraphics = new Graphics();
-  drawStars(starGraphics, stars);
-  app.stage.addChild(starGraphics);
+  // Generate mock galaxy data (temporary — issue #31 replaces with Colyseus)
+  const galaxyData = generateMockGalaxy();
 
-  // Subtle twinkle animation
-  let elapsed = 0;
-  app.ticker.add((ticker) => {
-    elapsed += ticker.deltaTime * 0.02;
-    starGraphics.clear();
-    for (const star of stars) {
-      const flicker = 0.5 + 0.5 * Math.sin(elapsed + star.x * 0.01 + star.y * 0.01);
-      const alpha = star.alpha * (0.6 + 0.4 * flicker);
-      starGraphics.circle(star.x, star.y, star.radius);
-      starGraphics.fill({ color: 0xfafafa, alpha });
-    }
+  // Build the galaxy renderer
+  const galaxyRenderer = new GalaxyRenderer((sectorId) => {
+    console.log(`[GalaxyMap] Sector ${sectorId} clicked`);
+  });
+  galaxyRenderer.setGalaxyData(galaxyData);
+
+  // Compute galaxy extent for viewport sizing
+  const extent = galaxyRenderer.getGalaxyExtent();
+  const worldWidth = extent.maxX - extent.minX;
+  const worldHeight = extent.maxY - extent.minY;
+
+  // Find starting sector position for initial camera center
+  const startSector = galaxyData.sectors.get(galaxyData.currentSectorId);
+  const centerX = startSector?.x ?? 0;
+  const centerY = startSector?.y ?? 0;
+
+  // Create the pixi-viewport for pan/zoom camera
+  const viewport = createGalaxyViewport(app, {
+    worldWidth,
+    worldHeight,
+    centerX,
+    centerY,
   });
 
-  return app;
-}
+  viewport.addChild(galaxyRenderer);
+  app.stage.addChild(viewport);
 
-function drawStars(graphics: Graphics, stars: Star[]): void {
-  for (const star of stars) {
-    graphics.circle(star.x, star.y, star.radius);
-    graphics.fill({ color: 0xfafafa, alpha: star.alpha });
-  }
+  // Handle container resize
+  const resizeObserver = new ResizeObserver(() => {
+    resizeViewport(viewport, app.screen.width, app.screen.height);
+  });
+  resizeObserver.observe(container);
+
+  return app;
 }

--- a/client/src/game/SectorNode.ts
+++ b/client/src/game/SectorNode.ts
@@ -1,0 +1,220 @@
+/**
+ * SectorNode — individual sector visual on the galaxy map.
+ * Renders as a procedural circle with hover/selected states,
+ * tooltip, and click handler for future navigation.
+ */
+import { Container, Graphics, Text } from "pixi.js";
+import {
+  Canvas,
+  Semantic,
+  Resource,
+  Player,
+  Neutral,
+  Alpha,
+  FontSize,
+  FontFamily,
+  FontWeight,
+} from "@void-market/shared";
+import type { SectorData } from "./mockGalaxyData.js";
+
+const BASE_RADIUS = 6;
+const PORT_RADIUS = 9;
+const CURRENT_SECTOR_RADIUS = 12;
+const HOVER_EXPAND = 3;
+const GLOW_RADIUS_EXTRA = 8;
+
+export type SectorClickHandler = (sectorId: number) => void;
+
+export class SectorNode extends Container {
+  private bg: Graphics;
+  private glow: Graphics;
+  private tooltip: Container;
+  private tooltipBg: Graphics;
+  private tooltipText: Text;
+  private _isHovered = false;
+  private sectorData: SectorData;
+  private isCurrent: boolean;
+  private hasLocalPlayer: boolean;
+  private onClick: SectorClickHandler | undefined;
+
+  constructor(
+    sector: SectorData,
+    isCurrent: boolean,
+    hasLocalPlayer: boolean,
+    onClick?: SectorClickHandler,
+  ) {
+    super();
+    this.sectorData = sector;
+    this.isCurrent = isCurrent;
+    this.hasLocalPlayer = hasLocalPlayer;
+    this.onClick = onClick;
+
+    this.position.set(sector.x, sector.y);
+    this.eventMode = "static";
+    this.cursor = "pointer";
+
+    // Glow layer (behind main circle)
+    this.glow = new Graphics();
+    this.glow.visible = false;
+    this.addChild(this.glow);
+
+    // Main circle
+    this.bg = new Graphics();
+    this.addChild(this.bg);
+
+    // Tooltip container (hidden by default)
+    this.tooltip = new Container();
+    this.tooltip.visible = false;
+    this.tooltipBg = new Graphics();
+    this.tooltipText = new Text({
+      text: "",
+      style: {
+        fontFamily: FontFamily.mono,
+        fontSize: FontSize.xs,
+        fontWeight: FontWeight.medium,
+        fill: Neutral.zinc100,
+      },
+    });
+    this.tooltip.addChild(this.tooltipBg);
+    this.tooltip.addChild(this.tooltipText);
+    this.addChild(this.tooltip);
+
+    this.draw();
+    this.setupInteraction();
+  }
+
+  private getRadius(): number {
+    if (this.isCurrent) return CURRENT_SECTOR_RADIUS;
+    if (this.sectorData.port) return PORT_RADIUS;
+    return BASE_RADIUS;
+  }
+
+  private getFillColor(): number {
+    if (this.isCurrent) return Semantic.primary;
+    if (this.hasLocalPlayer) return Player.player1;
+    if (this.sectorData.playerIds.length > 0) return Semantic.warning;
+    if (this.sectorData.port) {
+      return this.getPortColor(this.sectorData.port.portClass);
+    }
+    return Canvas.sectorNeutral;
+  }
+
+  private getPortColor(portClass: string): number {
+    // Color by what the port primarily trades
+    if (portClass.startsWith("S")) return Resource.fuelOre400;
+    if (portClass.charAt(1) === "S") return Resource.organics400;
+    return Resource.equipment400;
+  }
+
+  private draw(): void {
+    const radius = this.getRadius() + (this._isHovered ? HOVER_EXPAND : 0);
+    const color = this.getFillColor();
+
+    this.bg.clear();
+    this.bg.circle(0, 0, radius);
+    this.bg.fill({ color });
+
+    if (this._isHovered || this.isCurrent) {
+      this.bg.circle(0, 0, radius);
+      this.bg.stroke({
+        color: Canvas.sectorHover,
+        width: this._isHovered ? 2 : 1.5,
+        alpha: Alpha.hoverBorder,
+      });
+    }
+
+    // Glow for current sector and hovered
+    if (this.isCurrent || this._isHovered) {
+      this.glow.clear();
+      this.glow.circle(0, 0, radius + GLOW_RADIUS_EXTRA);
+      this.glow.fill({
+        color: this.isCurrent ? Semantic.primary : Canvas.sectorHover,
+        alpha: Alpha.controlledGlow,
+      });
+      this.glow.visible = true;
+    } else {
+      this.glow.visible = false;
+    }
+
+    // Expand hit area for easier clicking
+    const hitRadius = Math.max(radius + 8, 14);
+    const hitArea = new Graphics();
+    hitArea.circle(0, 0, hitRadius);
+    hitArea.fill({ color: 0x000000, alpha: 0.001 });
+    this.hitArea = {
+      contains: (x: number, y: number) => x * x + y * y <= hitRadius * hitRadius,
+    };
+  }
+
+  private setupInteraction(): void {
+    this.on("pointerover", () => { this.onPointerOver(); });
+    this.on("pointerout", () => { this.onPointerOut(); });
+    this.on("pointertap", () => { this.onTap(); });
+  }
+
+  private onPointerOver(): void {
+    this._isHovered = true;
+    this.draw();
+    this.showTooltip();
+  }
+
+  private onPointerOut(): void {
+    this._isHovered = false;
+    this.draw();
+    this.hideTooltip();
+  }
+
+  private onTap(): void {
+    this.onClick?.(this.sectorData.sectorId);
+  }
+
+  private showTooltip(): void {
+    const lines: string[] = [`Sector ${this.sectorData.sectorId}`];
+    if (this.sectorData.port) {
+      lines.push(
+        `Port: ${this.sectorData.port.name} [${this.sectorData.port.portClass}]`,
+      );
+    }
+    if (this.sectorData.playerIds.length > 0) {
+      lines.push(`Players: ${this.sectorData.playerIds.length}`);
+    }
+    lines.push(`Warps: ${this.sectorData.warps.length}`);
+
+    this.tooltipText.text = lines.join("\n");
+    const bounds = this.tooltipText.getBounds();
+    const pad = 6;
+
+    this.tooltipBg.clear();
+    this.tooltipBg.roundRect(
+      -pad,
+      -pad,
+      bounds.width + pad * 2,
+      bounds.height + pad * 2,
+      4,
+    );
+    this.tooltipBg.fill({ color: Neutral.zinc900, alpha: 0.92 });
+    this.tooltipBg.stroke({ color: Neutral.zinc700, width: 1 });
+
+    this.tooltip.position.set(
+      this.getRadius() + 12,
+      -bounds.height / 2,
+    );
+    this.tooltip.visible = true;
+  }
+
+  private hideTooltip(): void {
+    this.tooltip.visible = false;
+  }
+
+  /** Update sector data and redraw (for live Colyseus updates). */
+  update(
+    sector: SectorData,
+    isCurrent: boolean,
+    hasLocalPlayer: boolean,
+  ): void {
+    this.sectorData = sector;
+    this.isCurrent = isCurrent;
+    this.hasLocalPlayer = hasLocalPlayer;
+    this.draw();
+  }
+}

--- a/client/src/game/mockGalaxyData.ts
+++ b/client/src/game/mockGalaxyData.ts
@@ -1,0 +1,128 @@
+/**
+ * Temporary mock galaxy data generator.
+ * Produces 500 sectors with random positions, warps, and ports
+ * for client-side development. Will be replaced by Colyseus state
+ * sync from GalaxyRoom (issue #31).
+ */
+
+/** Plain data interface mirroring SectorSchema for rendering. */
+export interface SectorData {
+  sectorId: number;
+  x: number;
+  y: number;
+  warps: number[];
+  port: PortData | undefined;
+  playerIds: string[];
+}
+
+export interface PortData {
+  portId: string;
+  name: string;
+  portClass: string;
+}
+
+export interface GalaxyData {
+  sectors: Map<number, SectorData>;
+  currentPlayerId: string;
+  currentSectorId: number;
+}
+
+const SECTOR_COUNT = 500;
+const PORT_PROBABILITY = 0.4;
+const MIN_WARPS = 1;
+const MAX_WARPS = 4;
+const GALAXY_RADIUS = 4000;
+const PORT_CLASSES = ["BBS", "BSB", "SBB", "SSB", "SBS", "BSS", "SSS", "BBB"];
+
+function seededRandom(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+/** Generate 500 sectors in a spiral galaxy layout. */
+export function generateMockGalaxy(): GalaxyData {
+  const rng = seededRandom(42);
+  const sectors = new Map<number, SectorData>();
+
+  // Place sectors in a loose spiral / disc formation
+  for (let i = 1; i <= SECTOR_COUNT; i++) {
+    const angle = rng() * Math.PI * 2;
+    const dist = Math.sqrt(rng()) * GALAXY_RADIUS;
+    const jitterX = (rng() - 0.5) * 120;
+    const jitterY = (rng() - 0.5) * 120;
+
+    const hasPort = rng() < PORT_PROBABILITY;
+    const portClass = PORT_CLASSES[Math.floor(rng() * PORT_CLASSES.length)];
+
+    sectors.set(i, {
+      sectorId: i,
+      x: Math.cos(angle) * dist + jitterX,
+      y: Math.sin(angle) * dist + jitterY,
+      warps: [],
+      port: hasPort
+        ? { portId: `port-${i}`, name: `Port ${i}`, portClass }
+        : undefined,
+      playerIds: [],
+    });
+  }
+
+  // Build warp connections using nearest-neighbor + random links
+  const sectorList = [...sectors.values()];
+  for (const sector of sectorList) {
+    if (sector.warps.length >= MAX_WARPS) continue;
+
+    // Sort others by distance, pick nearest few
+    const others = sectorList
+      .filter((s) => s.sectorId !== sector.sectorId)
+      .map((s) => ({
+        id: s.sectorId,
+        dist: Math.hypot(s.x - sector.x, s.y - sector.y),
+      }))
+      .sort((a, b) => a.dist - b.dist);
+
+    const warpCount =
+      MIN_WARPS + Math.floor(rng() * (MAX_WARPS - MIN_WARPS + 1));
+    const targetCount = Math.min(warpCount, others.length);
+
+    for (let w = 0; w < targetCount; w++) {
+      const target = others[w];
+      if (
+        !sector.warps.includes(target.id) &&
+        sector.warps.length < MAX_WARPS
+      ) {
+        sector.warps.push(target.id);
+        // Bidirectional
+        const targetSector = sectors.get(target.id);
+        if (!targetSector) continue;
+        if (
+          !targetSector.warps.includes(sector.sectorId) &&
+          targetSector.warps.length < MAX_WARPS
+        ) {
+          targetSector.warps.push(sector.sectorId);
+        }
+      }
+    }
+  }
+
+  // Place a mock player in sector 1
+  const startSector = sectors.get(1);
+  if (startSector) {
+    startSector.playerIds.push("local-player");
+  }
+
+  // Scatter a few other players for visual testing
+  const otherPlayers = [42, 100, 250, 400];
+  for (const sid of otherPlayers) {
+    const s = sectors.get(sid);
+    if (s) s.playerIds.push(`npc-${sid}`);
+  }
+
+  return {
+    sectors,
+    currentPlayerId: "local-player",
+    currentSectorId: 1,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "clsx": "^2.1.0",
         "colyseus.js": "^0.16.0",
         "lucide-react": "^0.487.0",
+        "pixi-viewport": "^6.0.3",
         "pixi.js": "^8.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3540,7 +3541,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -3561,7 +3562,7 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3572,7 +3573,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4505,7 +4506,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5600,6 +5601,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5621,6 +5623,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5642,6 +5645,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5663,6 +5667,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5684,6 +5689,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5705,6 +5711,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5726,6 +5733,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5747,6 +5755,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5768,6 +5777,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5789,6 +5799,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5810,6 +5821,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6228,6 +6240,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi-viewport": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-6.0.3.tgz",
+      "integrity": "sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pixi.js": ">=8"
       }
     },
     "node_modules/pixi.js": {
@@ -7003,6 +7024,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7020,6 +7042,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7037,6 +7060,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7054,6 +7078,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7071,6 +7096,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7088,6 +7114,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7105,6 +7132,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7122,6 +7150,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7139,6 +7168,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7156,6 +7186,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7173,6 +7204,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7190,6 +7222,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7207,6 +7240,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7224,6 +7258,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7241,6 +7276,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7258,6 +7294,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7275,6 +7312,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7292,6 +7330,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7309,6 +7348,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7326,6 +7366,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7343,6 +7384,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7360,6 +7402,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7377,6 +7420,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7394,6 +7438,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7411,6 +7456,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7428,6 +7474,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7514,7 +7561,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Summary

Implements the PixiJS galaxy map renderer per issue #29. Renders 500 sectors as interactive nodes with warp connections as lines, color-coded by sector type.

### What's included

- **GalaxyRenderer** — Data-driven container that accepts galaxy state and renders sectors + warp routes
- **SectorNode** — Interactive sector visuals with hover glow, tooltip (sector ID, port class, player count), and click handler for future navigation
- **GalaxyViewport** — pixi-viewport camera with drag-to-pan, scroll-to-zoom, zoom limits (0.05x–3x), smooth deceleration
- **mockGalaxyData** — Temporary 500-sector generator with nearest-neighbor warp topology and ~40% port density (replaced by Colyseus state sync in #31)
- **PixiApp** — Updated to initialize galaxy renderer + viewport instead of placeholder starfield

### Color scheme (from shared design tokens)
| Sector type | Color |
|---|---|
| Empty | Neutral zinc-700 |
| Has port | Resource color (fuel=amber, organics=emerald, equipment=sky) |
| Other player present | Warning amber |
| Current player | Player red |
| Current sector | Primary violet with glow |

### Performance
- Container culling enabled for off-screen sectors
- Single Graphics batch for all warp lines
- Target: 60 FPS with 500 sectors

### Testing
- Build passes (`npm run build`)
- Client lint clean (`npm run lint --workspace=@void-market/client`)
- No existing client tests affected

Closes #29