### PR TITLE
P1-11: PostgreSQL database schema and migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,6 +1149,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3537,6 +3546,18 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -4088,7 +4109,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4098,7 +4118,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4148,7 +4167,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4195,7 +4213,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
       "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4340,7 +4357,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4364,7 +4380,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4377,7 +4392,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colyseus.js": {
@@ -4491,7 +4505,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4595,7 +4608,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4704,7 +4716,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5086,6 +5097,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5142,7 +5169,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5214,6 +5240,30 @@
       "license": "MIT",
       "dependencies": {
         "js-binary-schema-parser": "^2.0.3"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -5387,7 +5437,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5416,7 +5465,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ismobilejs": {
@@ -5462,6 +5510,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jiti": {
@@ -5980,7 +6043,6 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -5990,6 +6052,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -6067,6 +6138,31 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-pg-migrate": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
+      "integrity": "sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "~11.1.0",
+        "yargs": "~17.7.0"
+      },
+      "bin": {
+        "node-pg-migrate": "bin/node-pg-migrate.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "@types/pg": ">=6.0.0 <9.0.0",
+        "pg": ">=4.3.0 <9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/pg": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -6170,6 +6266,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-svg-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
@@ -6199,10 +6301,34 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/path-to-regexp": {
@@ -6221,6 +6347,95 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6304,6 +6519,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -6502,7 +6756,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6684,7 +6937,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6697,7 +6949,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6795,6 +7046,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6803,6 +7066,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -6832,7 +7104,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6847,7 +7118,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7872,7 +8142,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7915,7 +8184,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7956,11 +8224,19 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7977,7 +8253,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7996,7 +8271,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8022,10 +8296,13 @@
         "@colyseus/core": "^0.17.39",
         "@colyseus/ws-transport": "^0.17.9",
         "@void-market/shared": "*",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.20.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
+        "@types/pg": "^8.18.0",
         "tsx": "^4.21.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "clean": "tsc --build --clean",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "dev": "concurrently -k -n server,client -c blue,green \"npm run dev -w server\" \"npm run dev -w client\""
+    "dev": "concurrently -k -n server,client -c blue,green \"npm run dev -w server\" \"npm run dev -w client\"",
+    "migrate": "tsx server/src/db/migrate.ts up",
+    "migrate:down": "tsx server/src/db/migrate.ts down",
+    "db:seed": "tsx server/src/db/seed.ts"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -17,10 +17,13 @@
     "@colyseus/core": "^0.17.39",
     "@colyseus/ws-transport": "^0.17.9",
     "@void-market/shared": "*",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
+    "@types/pg": "^8.18.0",
     "tsx": "^4.21.0"
   }
 }

--- a/server/src/db/connection.ts
+++ b/server/src/db/connection.ts
@@ -1,0 +1,26 @@
+/**
+ * PostgreSQL connection pool for Void Market.
+ * Uses DATABASE_URL env var or falls back to local Docker Compose defaults.
+ */
+
+import pg from "pg";
+
+const DEFAULT_DATABASE_URL =
+  "postgresql://postgres:postgres@localhost:5432/voidmarket";
+
+const connectionString = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL;
+
+export const pool = new pg.Pool({ connectionString });
+
+/** Run a single parameterized query. */
+export async function query<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<pg.QueryResult<T>> {
+  return pool.query<T>(text, params);
+}
+
+/** Gracefully shut down the pool. */
+export async function closePool(): Promise<void> {
+  await pool.end();
+}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Database barrel export.
+ * Re-exports the connection pool, query helper, and teardown utility.
+ */
+export { pool, query, closePool } from "./connection.js";

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -1,0 +1,44 @@
+/**
+ * Programmatic migration runner for Void Market.
+ * Usage:
+ *   tsx server/src/db/migrate.ts up      — apply all pending migrations
+ *   tsx server/src/db/migrate.ts down     — revert last migration
+ */
+
+import { runner } from "node-pg-migrate";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = resolve(__dirname, "migrations");
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/voidmarket";
+
+const directionArg = process.argv[2] ?? "up";
+
+if (directionArg !== "up" && directionArg !== "down") {
+  console.error(`Usage: migrate.ts [up|down]`);
+  process.exit(1);
+}
+
+const direction: "up" | "down" = directionArg;
+
+async function main(): Promise<void> {
+  console.log(`Running migrations ${direction}…`);
+  await runner({
+    databaseUrl: DATABASE_URL,
+    dir: migrationsDir,
+    direction,
+    migrationsTable: "pgmigrations",
+    count: direction === "down" ? 1 : Infinity,
+    log: console.log.bind(console),
+  });
+  console.log(`Migrations ${direction} complete.`);
+}
+
+main().catch((err: unknown) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/server/src/db/migrations/001_create_users.ts
+++ b/server/src/db/migrations/001_create_users.ts
@@ -1,0 +1,35 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export const shorthands = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.sql(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
+
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    username: { type: "varchar(64)", notNull: true, unique: true },
+    email: { type: "varchar(255)", notNull: true, unique: true },
+    password_hash: { type: "varchar(255)", notNull: true },
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+    updated_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+  });
+
+  pgm.createIndex("users", "username");
+  pgm.createIndex("users", "email");
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable("users");
+}

--- a/server/src/db/migrations/002_create_players.ts
+++ b/server/src/db/migrations/002_create_players.ts
@@ -1,0 +1,94 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export const shorthands = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable("players", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    user_id: {
+      type: "uuid",
+      notNull: true,
+      references: "users",
+      onDelete: "CASCADE",
+    },
+    display_name: { type: "varchar(64)", notNull: true },
+    credits: { type: "numeric(15,2)", notNull: true, default: 10000 },
+    turns_remaining: { type: "integer", notNull: true, default: 500 },
+    turns_max: { type: "integer", notNull: true, default: 2000 },
+    current_sector_id: { type: "integer", notNull: true, default: 1 },
+    is_docked: { type: "boolean", notNull: true, default: false },
+    is_online: { type: "boolean", notNull: true, default: false },
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+    updated_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+  });
+
+  pgm.createIndex("players", "user_id");
+  pgm.createIndex("players", "current_sector_id");
+
+  pgm.createTable("ships", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    player_id: {
+      type: "uuid",
+      notNull: true,
+      unique: true,
+      references: "players",
+      onDelete: "CASCADE",
+    },
+    ship_class: { type: "varchar(32)", notNull: true, default: "'scout'" },
+    name: { type: "varchar(64)", notNull: true, default: "'Starter Ship'" },
+    cargo_holds: { type: "integer", notNull: true, default: 0 },
+    max_cargo_holds: { type: "integer", notNull: true, default: 25 },
+    speed: { type: "integer", notNull: true, default: 3 },
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+    updated_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+  });
+
+  pgm.createIndex("ships", "player_id");
+
+  pgm.createTable("cargo", {
+    id: { type: "serial", primaryKey: true },
+    ship_id: {
+      type: "uuid",
+      notNull: true,
+      references: "ships",
+      onDelete: "CASCADE",
+    },
+    commodity: { type: "varchar(32)", notNull: true },
+    quantity: { type: "integer", notNull: true, default: 0 },
+  });
+
+  pgm.createIndex("cargo", "ship_id");
+  pgm.addConstraint("cargo", "cargo_ship_commodity_unique", {
+    unique: ["ship_id", "commodity"],
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable("cargo");
+  pgm.dropTable("ships");
+  pgm.dropTable("players");
+}

--- a/server/src/db/migrations/003_create_galaxy.ts
+++ b/server/src/db/migrations/003_create_galaxy.ts
@@ -1,0 +1,95 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export const shorthands = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable("sectors", {
+    id: { type: "integer", primaryKey: true },
+    x: { type: "real", notNull: true, default: 0 },
+    y: { type: "real", notNull: true, default: 0 },
+  });
+
+  pgm.createTable("warps", {
+    sector_from_id: {
+      type: "integer",
+      notNull: true,
+      references: "sectors",
+      onDelete: "CASCADE",
+    },
+    sector_to_id: {
+      type: "integer",
+      notNull: true,
+      references: "sectors",
+      onDelete: "CASCADE",
+    },
+  });
+
+  pgm.addConstraint("warps", "warps_pkey", {
+    primaryKey: ["sector_from_id", "sector_to_id"],
+  });
+  pgm.createIndex("warps", "sector_from_id");
+  pgm.createIndex("warps", "sector_to_id");
+
+  pgm.createTable("ports", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    sector_id: {
+      type: "integer",
+      notNull: true,
+      unique: true,
+      references: "sectors",
+      onDelete: "CASCADE",
+    },
+    name: { type: "varchar(128)", notNull: true },
+    port_class: { type: "varchar(8)", notNull: true },
+    last_restock: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+  });
+
+  pgm.createIndex("ports", "sector_id");
+
+  pgm.createTable("port_commodities", {
+    id: { type: "serial", primaryKey: true },
+    port_id: {
+      type: "uuid",
+      notNull: true,
+      references: "ports",
+      onDelete: "CASCADE",
+    },
+    commodity: { type: "varchar(32)", notNull: true },
+    stock: { type: "integer", notNull: true, default: 0 },
+    max_stock: { type: "integer", notNull: true, default: 5000 },
+    buy_price: { type: "integer", notNull: true, default: 0 },
+    sell_price: { type: "integer", notNull: true, default: 0 },
+    port_buys: { type: "boolean", notNull: true, default: false },
+  });
+
+  pgm.createIndex("port_commodities", "port_id");
+  pgm.addConstraint(
+    "port_commodities",
+    "port_commodities_port_commodity_unique",
+    { unique: ["port_id", "commodity"] },
+  );
+
+  // Add FK from players.current_sector_id → sectors.id now that sectors exist
+  pgm.addConstraint("players", "players_current_sector_fk", {
+    foreignKeys: {
+      columns: "current_sector_id",
+      references: "sectors",
+    },
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropConstraint("players", "players_current_sector_fk");
+  pgm.dropTable("port_commodities");
+  pgm.dropTable("ports");
+  pgm.dropTable("warps");
+  pgm.dropTable("sectors");
+}

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -1,0 +1,198 @@
+/**
+ * Dev seed script — populates the database with a small test galaxy and sample players.
+ * Idempotent: safe to run multiple times (uses ON CONFLICT DO NOTHING).
+ *
+ * Usage: tsx server/src/db/seed.ts
+ */
+
+import {
+  STARTING_CREDITS,
+  STARTING_TURNS,
+  MAX_TURN_BANK,
+  STARTING_SECTOR_ID,
+  PORT_CLASS_CODES,
+  COMMODITIES,
+  BASE_PRICES,
+  MAX_PORT_STOCK,
+  PORT_CLASS_DEFS,
+  type Commodity,
+  PortTradeType,
+} from "@void-market/shared";
+import { pool, closePool } from "./connection.js";
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const SEED_SECTOR_COUNT = 50;
+const SEED_PORT_DENSITY = 0.6;
+const MIN_WARPS = 2;
+const MAX_WARPS = 4;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function randomFloat(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(randomFloat(min, max + 1));
+}
+
+function pickRandom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ── Seed Functions ───────────────────────────────────────────────────────────
+
+async function seedSectors(): Promise<void> {
+  console.log(`  Seeding ${SEED_SECTOR_COUNT} sectors…`);
+  const values: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  for (let i = 1; i <= SEED_SECTOR_COUNT; i++) {
+    const x = randomFloat(-500, 500);
+    const y = randomFloat(-500, 500);
+    values.push(`($${idx++}, $${idx++}, $${idx++})`);
+    params.push(i, x, y);
+  }
+
+  await pool.query(
+    `INSERT INTO sectors (id, x, y) VALUES ${values.join(", ")}
+     ON CONFLICT (id) DO NOTHING`,
+    params,
+  );
+}
+
+async function seedWarps(): Promise<void> {
+  console.log("  Seeding warp connections…");
+  const edges = new Set<string>();
+  const inserts: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  for (let from = 1; from <= SEED_SECTOR_COUNT; from++) {
+    const warpCount = randomInt(MIN_WARPS, MAX_WARPS);
+    for (let w = 0; w < warpCount; w++) {
+      let to = randomInt(1, SEED_SECTOR_COUNT);
+      if (to === from) to = (to % SEED_SECTOR_COUNT) + 1;
+      const key = `${from}-${to}`;
+      if (edges.has(key)) continue;
+      edges.add(key);
+      // Bidirectional warps
+      const reverseKey = `${to}-${from}`;
+      edges.add(reverseKey);
+      inserts.push(`($${idx++}, $${idx++})`);
+      params.push(from, to);
+      inserts.push(`($${idx++}, $${idx++})`);
+      params.push(to, from);
+    }
+  }
+
+  await pool.query(
+    `INSERT INTO warps (sector_from_id, sector_to_id) VALUES ${inserts.join(", ")}
+     ON CONFLICT DO NOTHING`,
+    params,
+  );
+}
+
+async function seedPorts(): Promise<void> {
+  console.log("  Seeding ports…");
+
+  for (let sectorId = 2; sectorId <= SEED_SECTOR_COUNT; sectorId++) {
+    if (Math.random() > SEED_PORT_DENSITY) continue;
+
+    const portClass = pickRandom(PORT_CLASS_CODES);
+    const portName = `Port ${sectorId}-${portClass}`;
+
+    const portResult = await pool.query<{ id: string }>(
+      `INSERT INTO ports (sector_id, name, port_class)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (sector_id) DO NOTHING
+       RETURNING id`,
+      [sectorId, portName, portClass],
+    );
+
+    if (portResult.rows.length === 0) continue;
+    const portId = portResult.rows[0].id;
+
+    const classDef = PORT_CLASS_DEFS[portClass];
+    for (const commodity of COMMODITIES) {
+      const buys = classDef.trades[commodity] === PortTradeType.Buying;
+      const basePrice = BASE_PRICES[commodity as Commodity];
+      const stock = randomInt(500, MAX_PORT_STOCK);
+      const buyPrice = buys ? 0 : Math.round(basePrice * 1.1);
+      const sellPrice = buys ? Math.round(basePrice * 0.9) : 0;
+
+      await pool.query(
+        `INSERT INTO port_commodities (port_id, commodity, stock, max_stock, buy_price, sell_price, port_buys)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (port_id, commodity) DO NOTHING`,
+        [portId, commodity, stock, MAX_PORT_STOCK, buyPrice, sellPrice, buys],
+      );
+    }
+  }
+}
+
+async function seedPlayers(): Promise<void> {
+  console.log("  Seeding sample players…");
+
+  const samplePlayers = [
+    { username: "alice", email: "alice@void.market", displayName: "Alice" },
+    { username: "bob", email: "bob@void.market", displayName: "Bob" },
+  ];
+
+  for (const p of samplePlayers) {
+    // Dummy password hash — never used in production
+    const dummyHash = "dev_seed_not_a_real_hash";
+
+    const userResult = await pool.query<{ id: string }>(
+      `INSERT INTO users (username, email, password_hash)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (username) DO NOTHING
+       RETURNING id`,
+      [p.username, p.email, dummyHash],
+    );
+
+    if (userResult.rows.length === 0) continue;
+    const userId = userResult.rows[0].id;
+
+    const playerResult = await pool.query<{ id: string }>(
+      `INSERT INTO players (user_id, display_name, credits, turns_remaining, turns_max, current_sector_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [
+        userId,
+        p.displayName,
+        STARTING_CREDITS,
+        STARTING_TURNS,
+        MAX_TURN_BANK,
+        STARTING_SECTOR_ID,
+      ],
+    );
+
+    const playerId = playerResult.rows[0].id;
+
+    await pool.query(
+      `INSERT INTO ships (player_id, ship_class, name, cargo_holds, max_cargo_holds, speed)
+       VALUES ($1, 'scout', 'Starter Ship', 0, 25, 3)`,
+      [playerId],
+    );
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log("🌌 Seeding Void Market database…");
+  await seedSectors();
+  await seedWarps();
+  await seedPorts();
+  await seedPlayers();
+  console.log("✅ Seed complete.");
+  await closePool();
+}
+
+main().catch((err: unknown) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Sets up database migration tool, creates schema for users/players/galaxy/ports, adds seed script.

## Changes
- **node-pg-migrate** added to server workspace for TypeScript migrations
- **Migration 001**: `users` table — id (UUID), username, email, password_hash, timestamps
- **Migration 002**: `players`, `ships`, `cargo` tables with foreign keys and indexes
- **Migration 003**: `sectors`, `warps`, `ports`, `port_commodities` tables with FK back to players
- **connection.ts**: PostgreSQL pool (defaults to local Docker Compose)
- **seed.ts**: 50-sector dev galaxy with ports, commodities, and sample players
- **npm scripts**: `migrate`, `migrate:down`, `db:seed`

Closes #25