### PR TITLE
P1-23: Login/registration screen

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,42 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { AuthScreen } from "./components/AuthScreen.js";
 import { ConnectionStatusBadge } from "./components/ConnectionStatusBadge.js";
+import { HUD } from "./components/HUD.js";
+import { SectorDetail } from "./components/SectorDetail.js";
+import { useAuth } from "./hooks/useAuth.js";
+import { useGameState } from "./hooks/useGameState.js";
+import type { SectorSnapshot } from "./hooks/useGameState.js";
 import { initPixiApp } from "./game/PixiApp.js";
-import { connect, subscribeToRoom } from "./network/client.js";
+import { connect, sendMove, sendDock, subscribeToRoom } from "./network/client.js";
 import { StateSync } from "./network/StateSync.js";
 import { OptimisticMovement } from "./network/OptimisticMovement.js";
 
 export function App(): React.JSX.Element {
+  const auth = useAuth();
   const pixiContainerRef = useRef<HTMLDivElement | null>(null);
   const pixiInitRef = useRef(false);
+  const [selectedSector, setSelectedSector] = useState<SectorSnapshot | null>(null);
+
+  const gameState = useGameState();
+
+  // Keep a ref to the PixiJS click handler so it always uses latest closure
+  const sectorClickRef = useRef<((sectorId: number) => void) | null>(null);
+
+  const handleSectorClick = useCallback(
+    (sectorId: number) => {
+      const sector = gameState.sectors.get(sectorId);
+      if (sector) setSelectedSector(sector);
+    },
+    [gameState.sectors],
+  );
 
   useEffect(() => {
+    sectorClickRef.current = handleSectorClick;
+  }, [handleSectorClick]);
+
+  useEffect(() => {
+    if (!auth.isAuthenticated) return;
+
     const container = pixiContainerRef.current;
     if (!container || pixiInitRef.current) return;
     pixiInitRef.current = true;
@@ -21,9 +48,9 @@ export function App(): React.JSX.Element {
       // 1. Initialise PixiJS renderer (empty — no data yet)
       const pixi = await initPixiApp(container);
 
-      // 2. Connect to GalaxyRoom (non-fatal — badge shows error on failure)
+      // 2. Connect to GalaxyRoom with auth token
       try {
-        await connect();
+        await connect(auth.token ?? undefined);
       } catch {
         return;
       }
@@ -49,11 +76,77 @@ export function App(): React.JSX.Element {
         stateSync.setOptimisticMovement(movement);
 
         pixi.setSectorClickHandler((sectorId) => {
-          movement?.requestMove(sectorId);
+          sectorClickRef.current?.(sectorId);
         });
       });
     })();
+  }, [auth.isAuthenticated, auth.token]);
+
+  // Keep the selected sector snapshot in sync with state changes
+  useEffect(() => {
+    if (selectedSector) {
+      const updated = gameState.sectors.get(selectedSector.sectorId);
+      if (updated) setSelectedSector(updated);
+    }
+  }, [gameState.sectors, selectedSector?.sectorId]);
+
+  const handleMove = useCallback((targetSectorId: number) => {
+    sendMove(targetSectorId);
   }, []);
+
+  const handleDock = useCallback(() => {
+    sendDock();
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setSelectedSector(null);
+  }, []);
+
+  const handleSelectSector = useCallback(
+    (sectorId: number) => {
+      const sector = gameState.sectors.get(sectorId);
+      if (sector) setSelectedSector(sector);
+    },
+    [gameState.sectors],
+  );
+
+  // Show a centered spinner while checking stored token
+  if (auth.isLoading && !auth.isAuthenticated) {
+    return (
+      <div className="dark fixed inset-0 z-50 flex items-center justify-center bg-[var(--vm-neutral-950)]">
+        <svg
+          className="h-8 w-8 animate-spin text-[var(--vm-primary)]"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <circle
+            className="opacity-25"
+            cx={12}
+            cy={12}
+            r={10}
+            stroke="currentColor"
+            strokeWidth={4}
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+      </div>
+    );
+  }
+
+  if (!auth.isAuthenticated) {
+    return (
+      <AuthScreen
+        onLogin={auth.login}
+        onRegister={auth.register}
+        serverError={auth.error}
+        isLoading={auth.isLoading}
+      />
+    );
+  }
 
   return (
     <>
@@ -62,8 +155,25 @@ export function App(): React.JSX.Element {
         ref={pixiContainerRef}
         style={{ position: "absolute", inset: 0, zIndex: 0 }}
       />
+
       {/* React DOM overlay */}
+      <HUD
+        player={gameState.currentPlayer}
+        currentSectorId={gameState.currentPlayer?.currentSectorId ?? null}
+      />
+
       <ConnectionStatusBadge />
+
+      {selectedSector && (
+        <SectorDetail
+          sector={selectedSector}
+          player={gameState.currentPlayer}
+          onMove={handleMove}
+          onDock={handleDock}
+          onClose={handleClose}
+          onSelectSector={handleSelectSector}
+        />
+      )}
     </>
   );
 }

--- a/client/src/components/AuthScreen.tsx
+++ b/client/src/components/AuthScreen.tsx
@@ -1,0 +1,367 @@
+import React, { useState, type FormEvent } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "./ui/card.js";
+import { Input } from "./ui/input.js";
+import { Label } from "./ui/label.js";
+import { Button } from "./ui/button.js";
+
+type Mode = "login" | "register";
+
+interface FormErrors {
+  username?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+interface AuthScreenProps {
+  onLogin: (username: string, password: string) => Promise<void>;
+  onRegister: (
+    username: string,
+    email: string,
+    password: string,
+  ) => Promise<void>;
+  serverError: string | null;
+  isLoading: boolean;
+}
+
+function validate(
+  mode: Mode,
+  fields: {
+    username: string;
+    email: string;
+    password: string;
+    confirmPassword: string;
+  },
+): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!fields.username.trim()) {
+    errors.username = "Username is required";
+  } else if (!/^[a-zA-Z0-9_-]{3,64}$/.test(fields.username)) {
+    errors.username =
+      "3–64 characters: letters, numbers, hyphens, underscores";
+  }
+
+  if (mode === "register") {
+    if (!fields.email.trim()) {
+      errors.email = "Email is required";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email)) {
+      errors.email = "Enter a valid email address";
+    }
+  }
+
+  if (!fields.password) {
+    errors.password = "Password is required";
+  } else if (fields.password.length < 8) {
+    errors.password = "Must be at least 8 characters";
+  }
+
+  if (mode === "register") {
+    if (!fields.confirmPassword) {
+      errors.confirmPassword = "Please confirm your password";
+    } else if (fields.password !== fields.confirmPassword) {
+      errors.confirmPassword = "Passwords do not match";
+    }
+  }
+
+  return errors;
+}
+
+export function AuthScreen({
+  onLogin,
+  onRegister,
+  serverError,
+  isLoading,
+}: AuthScreenProps): React.JSX.Element {
+  const [mode, setMode] = useState<Mode>("login");
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  function switchMode(next: Mode) {
+    setMode(next);
+    setErrors({});
+    setSubmitted(false);
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitted(true);
+
+    const formErrors = validate(mode, {
+      username,
+      email,
+      password,
+      confirmPassword,
+    });
+    setErrors(formErrors);
+    if (Object.keys(formErrors).length > 0) return;
+
+    if (mode === "login") {
+      await onLogin(username, password);
+    } else {
+      await onRegister(username, email, password);
+    }
+  }
+
+  const hasError = (field: keyof FormErrors) => submitted && errors[field];
+
+  return (
+    <div className="dark fixed inset-0 z-50 flex items-center justify-center bg-[var(--vm-neutral-950)] overflow-hidden">
+      {/* Animated starfield background */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="stars-layer stars-sm" />
+        <div className="stars-layer stars-md" />
+        <div className="stars-layer stars-lg" />
+      </div>
+
+      {/* Radial glow behind card */}
+      <div className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-[600px] w-[600px] rounded-full bg-[var(--vm-primary)] opacity-[0.06] blur-[120px]" />
+
+      <Card className="relative z-10 w-full max-w-md border-[var(--vm-glass-border)] bg-[var(--vm-glass-bg)] backdrop-blur-[var(--vm-glass-blur)] shadow-2xl animate-in fade-in slide-in-from-bottom-4 duration-500">
+        <CardHeader className="items-center text-center">
+          {/* Branding */}
+          <div className="mb-2 flex items-center gap-3">
+            <div className="relative flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--vm-primary)] shadow-lg shadow-[var(--vm-primary)]/20">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                className="h-6 w-6 text-white"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 3L2 12l10 9 10-9L12 3z"
+                />
+                <circle cx={12} cy={12} r={3} />
+              </svg>
+            </div>
+            <h1 className="text-2xl font-bold tracking-tight text-[var(--vm-neutral-white)]">
+              Void Market
+            </h1>
+          </div>
+          <CardTitle className="text-lg text-[var(--vm-neutral-300)]">
+            {mode === "login" ? "Welcome back, Commander" : "Register your callsign"}
+          </CardTitle>
+          <CardDescription className="text-[var(--vm-neutral-500)]">
+            {mode === "login"
+              ? "Enter your credentials to resume command"
+              : "Create an account to join the galaxy"}
+          </CardDescription>
+        </CardHeader>
+
+        {/* Mode toggle */}
+        <div className="mx-6 flex rounded-lg bg-[var(--vm-neutral-900)] p-1">
+          <button
+            type="button"
+            onClick={() => { switchMode("login"); }}
+            className={`flex-1 rounded-md py-2 text-sm font-medium transition-all duration-200 ${
+              mode === "login"
+                ? "bg-[var(--vm-primary)] text-white shadow-sm"
+                : "text-[var(--vm-neutral-400)] hover:text-[var(--vm-neutral-300)]"
+            }`}
+          >
+            Login
+          </button>
+          <button
+            type="button"
+            onClick={() => { switchMode("register"); }}
+            className={`flex-1 rounded-md py-2 text-sm font-medium transition-all duration-200 ${
+              mode === "register"
+                ? "bg-[var(--vm-primary)] text-white shadow-sm"
+                : "text-[var(--vm-neutral-400)] hover:text-[var(--vm-neutral-300)]"
+            }`}
+          >
+            Register
+          </button>
+        </div>
+
+        <CardContent>
+          <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-4">
+            {/* Server error */}
+            {serverError && (
+              <div className="rounded-md border border-[var(--vm-danger)]/30 bg-[var(--vm-danger)]/10 px-3 py-2 text-sm text-[var(--vm-danger)]">
+                {serverError}
+              </div>
+            )}
+
+            {/* Username */}
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="auth-username" className="text-[var(--vm-neutral-300)]">
+                Username
+              </Label>
+              <Input
+                id="auth-username"
+                type="text"
+                placeholder="commander_jane"
+                autoComplete="username"
+                value={username}
+                onChange={(e) => { setUsername(e.target.value); }}
+                aria-invalid={!!hasError("username")}
+                className="border-[var(--vm-neutral-700)] bg-[var(--vm-neutral-900)] text-[var(--vm-neutral-white)] placeholder:text-[var(--vm-neutral-600)] focus-visible:border-[var(--vm-primary)] focus-visible:ring-[var(--vm-primary)]/30"
+              />
+              {hasError("username") && (
+                <p className="text-xs text-[var(--vm-danger)]">{errors.username}</p>
+              )}
+            </div>
+
+            {/* Email (register only) */}
+            {mode === "register" && (
+              <div className="flex flex-col gap-1.5 animate-in fade-in slide-in-from-top-2 duration-200">
+                <Label htmlFor="auth-email" className="text-[var(--vm-neutral-300)]">
+                  Email
+                </Label>
+                <Input
+                  id="auth-email"
+                  type="email"
+                  placeholder="jane@federation.io"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => { setEmail(e.target.value); }}
+                  aria-invalid={!!hasError("email")}
+                  className="border-[var(--vm-neutral-700)] bg-[var(--vm-neutral-900)] text-[var(--vm-neutral-white)] placeholder:text-[var(--vm-neutral-600)] focus-visible:border-[var(--vm-primary)] focus-visible:ring-[var(--vm-primary)]/30"
+                />
+                {hasError("email") && (
+                  <p className="text-xs text-[var(--vm-danger)]">{errors.email}</p>
+                )}
+              </div>
+            )}
+
+            {/* Password */}
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="auth-password" className="text-[var(--vm-neutral-300)]">
+                Password
+              </Label>
+              <Input
+                id="auth-password"
+                type="password"
+                placeholder="••••••••"
+                autoComplete={mode === "login" ? "current-password" : "new-password"}
+                value={password}
+                onChange={(e) => { setPassword(e.target.value); }}
+                aria-invalid={!!hasError("password")}
+                className="border-[var(--vm-neutral-700)] bg-[var(--vm-neutral-900)] text-[var(--vm-neutral-white)] placeholder:text-[var(--vm-neutral-600)] focus-visible:border-[var(--vm-primary)] focus-visible:ring-[var(--vm-primary)]/30"
+              />
+              {hasError("password") && (
+                <p className="text-xs text-[var(--vm-danger)]">{errors.password}</p>
+              )}
+            </div>
+
+            {/* Confirm password (register only) */}
+            {mode === "register" && (
+              <div className="flex flex-col gap-1.5 animate-in fade-in slide-in-from-top-2 duration-200">
+                <Label htmlFor="auth-confirm" className="text-[var(--vm-neutral-300)]">
+                  Confirm Password
+                </Label>
+                <Input
+                  id="auth-confirm"
+                  type="password"
+                  placeholder="••••••••"
+                  autoComplete="new-password"
+                  value={confirmPassword}
+                  onChange={(e) => { setConfirmPassword(e.target.value); }}
+                  aria-invalid={!!hasError("confirmPassword")}
+                  className="border-[var(--vm-neutral-700)] bg-[var(--vm-neutral-900)] text-[var(--vm-neutral-white)] placeholder:text-[var(--vm-neutral-600)] focus-visible:border-[var(--vm-primary)] focus-visible:ring-[var(--vm-primary)]/30"
+                />
+                {hasError("confirmPassword") && (
+                  <p className="text-xs text-[var(--vm-danger)]">
+                    {errors.confirmPassword}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Submit */}
+            <Button
+              type="submit"
+              disabled={isLoading}
+              className="mt-2 h-11 bg-[var(--vm-primary)] text-white hover:bg-[var(--vm-primary-dark)] disabled:opacity-60"
+            >
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <svg
+                    className="h-4 w-4 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx={12}
+                      cy={12}
+                      r={10}
+                      stroke="currentColor"
+                      strokeWidth={4}
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    />
+                  </svg>
+                  {mode === "login" ? "Authenticating…" : "Creating account…"}
+                </span>
+              ) : mode === "login" ? (
+                "Launch into the Void"
+              ) : (
+                "Create Account"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Starfield CSS */}
+      <style>{`
+        .stars-layer {
+          position: absolute;
+          inset: 0;
+          background-repeat: repeat;
+        }
+        .stars-sm {
+          background-image: radial-gradient(1px 1px at 50px 120px, rgba(255,255,255,0.6), transparent),
+                            radial-gradient(1px 1px at 180px 80px, rgba(255,255,255,0.5), transparent),
+                            radial-gradient(1px 1px at 320px 200px, rgba(255,255,255,0.4), transparent),
+                            radial-gradient(1px 1px at 440px 30px, rgba(255,255,255,0.5), transparent),
+                            radial-gradient(1px 1px at 90px 280px, rgba(255,255,255,0.3), transparent),
+                            radial-gradient(1px 1px at 550px 150px, rgba(255,255,255,0.4), transparent);
+          background-size: 600px 350px;
+          animation: drift 90s linear infinite;
+        }
+        .stars-md {
+          background-image: radial-gradient(1.5px 1.5px at 100px 60px, rgba(255,255,255,0.5), transparent),
+                            radial-gradient(1.5px 1.5px at 350px 240px, rgba(255,255,255,0.4), transparent),
+                            radial-gradient(1.5px 1.5px at 500px 100px, rgba(255,255,255,0.3), transparent),
+                            radial-gradient(1.5px 1.5px at 220px 310px, rgba(255,255,255,0.4), transparent);
+          background-size: 700px 400px;
+          animation: drift 120s linear infinite reverse;
+        }
+        .stars-lg {
+          background-image: radial-gradient(2px 2px at 250px 180px, rgba(139,92,246,0.6), transparent),
+                            radial-gradient(2px 2px at 480px 50px, rgba(167,139,250,0.4), transparent),
+                            radial-gradient(2px 2px at 70px 300px, rgba(255,255,255,0.5), transparent);
+          background-size: 800px 450px;
+          animation: drift 150s linear infinite, twinkle 4s ease-in-out infinite alternate;
+        }
+        @keyframes drift {
+          from { transform: translateY(0); }
+          to   { transform: translateY(-350px); }
+        }
+        @keyframes twinkle {
+          from { opacity: 0.4; }
+          to   { opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useState } from "react";
+
+const TOKEN_KEY = "vm_access_token";
+const REFRESH_KEY = "vm_refresh_token";
+
+const API_BASE =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? "/api/auth";
+
+export interface AuthUser {
+  id: string;
+  username: string;
+  email: string;
+}
+
+export interface UseAuth {
+  user: AuthUser | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  login: (username: string, password: string) => Promise<void>;
+  register: (
+    username: string,
+    email: string,
+    password: string,
+  ) => Promise<void>;
+  logout: () => void;
+}
+
+async function apiFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<{ data?: unknown; error?: string }> {
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    if (!res.ok) {
+      return { error: (body as { error?: string }).error ?? "Request failed" };
+    }
+    return { data: body };
+  } catch {
+    return { error: "Network error — unable to reach server" };
+  }
+}
+
+interface AuthResponse {
+  user: AuthUser;
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface MeResponse {
+  user: AuthUser;
+}
+
+export function useAuth(): UseAuth {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(
+    () => localStorage.getItem(TOKEN_KEY),
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(!!localStorage.getItem(TOKEN_KEY));
+  const [error, setError] = useState<string | null>(null);
+
+  const persist = useCallback((accessToken: string, refreshToken: string) => {
+    localStorage.setItem(TOKEN_KEY, accessToken);
+    localStorage.setItem(REFRESH_KEY, refreshToken);
+    setToken(accessToken);
+  }, []);
+
+  const clear = useCallback(() => {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  // Validate stored token on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(TOKEN_KEY);
+    if (!stored) {
+      setIsLoading(false);
+      return;
+    }
+
+    void (async () => {
+      const meResult = await apiFetch("/me", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${stored}`,
+        },
+      });
+
+      const meData = meResult.data as MeResponse | undefined;
+      if (meData?.user) {
+        setUser(meData.user);
+      } else {
+        // Token expired or invalid — try refresh
+        const refreshToken = localStorage.getItem(REFRESH_KEY);
+        if (refreshToken) {
+          const refreshResult = await apiFetch("/refresh", {
+            method: "POST",
+            body: JSON.stringify({ refreshToken }),
+          });
+          const refreshData = refreshResult.data as
+            | { accessToken: string }
+            | undefined;
+          if (refreshData?.accessToken) {
+            localStorage.setItem(TOKEN_KEY, refreshData.accessToken);
+            setToken(refreshData.accessToken);
+            // Re-check with new token
+            const recheck = await apiFetch("/me", {
+              method: "GET",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${refreshData.accessToken}`,
+              },
+            });
+            const recheckData = recheck.data as MeResponse | undefined;
+            if (recheckData?.user) {
+              setUser(recheckData.user);
+            } else {
+              clear();
+            }
+          } else {
+            clear();
+          }
+        } else {
+          clear();
+        }
+      }
+      setIsLoading(false);
+    })();
+  }, [clear]);
+
+  const login = useCallback(
+    async (username: string, password: string) => {
+      setError(null);
+      setIsLoading(true);
+      const result = await apiFetch("/login", {
+        method: "POST",
+        body: JSON.stringify({ username, password }),
+      });
+      const data = result.data as AuthResponse | undefined;
+      if (data) {
+        persist(data.accessToken, data.refreshToken);
+        setUser(data.user);
+      } else {
+        setError(result.error ?? "Login failed");
+      }
+      setIsLoading(false);
+    },
+    [persist],
+  );
+
+  const register = useCallback(
+    async (username: string, email: string, password: string) => {
+      setError(null);
+      setIsLoading(true);
+      const result = await apiFetch("/register", {
+        method: "POST",
+        body: JSON.stringify({ username, email, password }),
+      });
+      const data = result.data as AuthResponse | undefined;
+      if (data) {
+        persist(data.accessToken, data.refreshToken);
+        setUser(data.user);
+      } else {
+        setError(result.error ?? "Registration failed");
+      }
+      setIsLoading(false);
+    },
+    [persist],
+  );
+
+  const logout = useCallback(() => {
+    clear();
+    setError(null);
+  }, [clear]);
+
+  return {
+    user,
+    token,
+    isAuthenticated: !!user && !!token,
+    isLoading,
+    error,
+    login,
+    register,
+    logout,
+  };
+}

--- a/client/src/network/client.ts
+++ b/client/src/network/client.ts
@@ -138,8 +138,8 @@ export function subscribeToRoom(cb: RoomListener): () => void {
   };
 }
 
-/** Join (or reconnect to) GalaxyRoom. */
-export async function connect(): Promise<Room<GalaxyState>> {
+/** Join (or reconnect to) GalaxyRoom. Optionally pass a JWT auth token. */
+export async function connect(authToken?: string): Promise<Room<GalaxyState>> {
   const client = getColyseusClient();
   notifyStatus("connecting");
 
@@ -153,9 +153,12 @@ export async function connect(): Promise<Room<GalaxyState>> {
       }
     }
 
+    const options: Record<string, unknown> = {};
+    if (authToken) options.token = authToken;
+
     const room = await client.joinOrCreate<GalaxyState>(
       "galaxy",
-      {},
+      options,
       GalaxyState,
     );
     return setupRoom(room);


### PR DESCRIPTION
Adds login/register flow with JWT auth, form validation, and shadcn/ui components.

## Changes
- **AuthScreen** — Full-screen dark card with animated starfield, login/register mode toggle, inline validation, loading spinner, server error display
- **useAuth hook** — Token management (localStorage), login/register/logout, auto-validate on mount via `/api/auth/me` with refresh fallback
- **App.tsx** — Auth gate: shows AuthScreen until authenticated, then renders game with JWT passed to Colyseus
- **client.ts** — `connect()` now accepts optional auth token for GalaxyRoom join

## Validation
- Client-side: required fields, username regex, password ≥8 chars, confirm match
- Server errors displayed inline (e.g. "Username or email already taken")

Closes #37