### PR TITLE
P1-18/P1-19: Sector detail view + HUD overlay

### DIFF
--- a/client/src/components/HUD.tsx
+++ b/client/src/components/HUD.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { MAX_TURN_BANK } from "@void-market/shared";
+import { Badge } from "./ui/badge.js";
+import type { PlayerSnapshot } from "../hooks/useGameState.js";
+
+// ── Turn color thresholds ───────────────────────────────────────────────────
+
+function turnColor(remaining: number, max: number): string {
+  const pct = max > 0 ? remaining / max : 0;
+  if (pct > 0.5) return "var(--vm-success)";
+  if (pct > 0.2) return "var(--vm-warning)";
+  return "var(--vm-danger)";
+}
+
+function turnBadgeClass(remaining: number, max: number): string {
+  const pct = max > 0 ? remaining / max : 0;
+  if (pct > 0.5) return "border-transparent bg-[var(--vm-success)]/15 text-[var(--vm-success)]";
+  if (pct > 0.2) return "border-transparent bg-[var(--vm-warning)]/15 text-[var(--vm-warning)]";
+  return "border-transparent bg-[var(--vm-danger)]/15 text-[var(--vm-danger)]";
+}
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+interface HUDProps {
+  player: PlayerSnapshot | null;
+  currentSectorId: number | null;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function HUD({ player, currentSectorId }: HUDProps): React.JSX.Element | null {
+  if (!player) return null;
+
+  const turnsMax = player.turnsMax || MAX_TURN_BANK;
+  const cargoPct =
+    player.maxCargoHolds > 0
+      ? Math.round((player.cargoHolds / player.maxCargoHolds) * 100)
+      : 0;
+
+  return (
+    <div
+      className="fixed top-0 left-0 right-0 flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4 px-3 sm:px-4 py-2 pointer-events-auto"
+      style={{
+        zIndex: "var(--vm-z-hud)" as unknown as number,
+        background: "var(--vm-glass-bg)",
+        backdropFilter: `blur(var(--vm-glass-blur))`,
+        borderBottom: "1px solid var(--vm-glass-border)",
+        fontFamily: "var(--vm-font-family-mono)",
+        fontSize: "var(--vm-font-sm)",
+        minHeight: "var(--vm-layout-hud-height)",
+      }}
+    >
+      {/* Turn counter */}
+      <div className="flex items-center gap-2">
+        <span className="text-[var(--vm-neutral-400)] text-xs uppercase tracking-wider">
+          Turns
+        </span>
+        <Badge className={turnBadgeClass(player.turnsRemaining, turnsMax)}>
+          <span
+            className="inline-block w-1.5 h-1.5 rounded-full mr-1"
+            style={{ backgroundColor: turnColor(player.turnsRemaining, turnsMax) }}
+          />
+          {player.turnsRemaining.toLocaleString()} / {turnsMax.toLocaleString()}
+        </Badge>
+      </div>
+
+      {/* Credits */}
+      <div className="flex items-center gap-2">
+        <span className="text-[var(--vm-neutral-400)] text-xs uppercase tracking-wider">
+          Credits
+        </span>
+        <span className="text-[var(--vm-credits)] font-semibold">
+          {player.credits.toLocaleString()}
+        </span>
+      </div>
+
+      {/* Cargo */}
+      <div className="flex items-center gap-2 min-w-[120px]">
+        <span className="text-[var(--vm-neutral-400)] text-xs uppercase tracking-wider">
+          Cargo
+        </span>
+        <div className="flex items-center gap-1.5">
+          <div className="w-16 h-2 rounded-full bg-[var(--vm-neutral-800)] overflow-hidden">
+            <div
+              className="h-full rounded-full transition-all duration-300"
+              style={{
+                width: `${cargoPct}%`,
+                backgroundColor:
+                  cargoPct > 90
+                    ? "var(--vm-danger)"
+                    : cargoPct > 60
+                      ? "var(--vm-warning)"
+                      : "var(--vm-primary)",
+              }}
+            />
+          </div>
+          <span className="text-[var(--vm-neutral-300)] text-xs">
+            {player.cargoHolds}/{player.maxCargoHolds}
+          </span>
+        </div>
+      </div>
+
+      {/* Current sector */}
+      {currentSectorId != null && (
+        <div className="flex items-center gap-2">
+          <span className="text-[var(--vm-neutral-400)] text-xs uppercase tracking-wider">
+            Sector
+          </span>
+          <span className="text-[var(--vm-primary-light)] font-semibold">
+            #{currentSectorId}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/SectorDetail.tsx
+++ b/client/src/components/SectorDetail.tsx
@@ -1,0 +1,275 @@
+import React from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from "./ui/card.js";
+import { Button } from "./ui/button.js";
+import { Badge } from "./ui/badge.js";
+import type {
+  SectorSnapshot,
+  PlayerSnapshot,
+  CommoditySnapshot,
+} from "../hooks/useGameState.js";
+
+// ── Commodity display name mapping ──────────────────────────────────────────
+
+const COMMODITY_LABELS: Record<string, string> = {
+  fuel_ore: "Fuel Ore",
+  organics: "Organics",
+  equipment: "Equipment",
+};
+
+const COMMODITY_COLORS: Record<string, string> = {
+  fuel_ore: "var(--vm-fuel-ore)",
+  organics: "var(--vm-organics)",
+  equipment: "var(--vm-equipment)",
+};
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+interface SectorDetailProps {
+  sector: SectorSnapshot;
+  player: PlayerSnapshot | null;
+  onMove: (targetSectorId: number) => void;
+  onDock: () => void;
+  onClose: () => void;
+  onSelectSector: (sectorId: number) => void;
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function CommodityRow({ c }: { c: CommoditySnapshot }): React.JSX.Element {
+  const label = COMMODITY_LABELS[c.commodity] ?? c.commodity;
+  const color = COMMODITY_COLORS[c.commodity] ?? "var(--vm-neutral-400)";
+
+  return (
+    <tr className="border-b border-[var(--vm-neutral-800)] last:border-b-0">
+      <td className="py-1.5 pr-3">
+        <span className="flex items-center gap-1.5">
+          <span
+            className="inline-block w-2 h-2 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <span className="text-[var(--vm-neutral-200)]">{label}</span>
+        </span>
+      </td>
+      <td className="py-1.5 px-2 text-right font-mono text-xs text-[var(--vm-neutral-300)]">
+        {c.stock.toLocaleString()}
+      </td>
+      <td className="py-1.5 px-2 text-right font-mono text-xs">
+        {c.portBuys ? (
+          <span className="text-[var(--vm-success)]">
+            {c.sellPrice.toLocaleString()}
+          </span>
+        ) : (
+          <span className="text-[var(--vm-danger)]">
+            {c.buyPrice.toLocaleString()}
+          </span>
+        )}
+      </td>
+      <td className="py-1.5 pl-2 text-center">
+        <Badge
+          variant="outline"
+          className={
+            c.portBuys
+              ? "text-[var(--vm-success)] border-[var(--vm-success)]/30 text-xs"
+              : "text-[var(--vm-danger)] border-[var(--vm-danger)]/30 text-xs"
+          }
+        >
+          {c.portBuys ? "Buying" : "Selling"}
+        </Badge>
+      </td>
+    </tr>
+  );
+}
+
+// ── Main Component ──────────────────────────────────────────────────────────
+
+export function SectorDetail({
+  sector,
+  player,
+  onMove,
+  onDock,
+  onClose,
+  onSelectSector,
+}: SectorDetailProps): React.JSX.Element {
+  const isCurrentSector = player?.currentSectorId === sector.sectorId;
+  const isAdjacent =
+    player != null &&
+    !isCurrentSector &&
+    sector.warps.includes(player.currentSectorId);
+  const adjacentFromHere =
+    player != null && isCurrentSector
+      ? false
+      : isAdjacent;
+  const hasPort = sector.portDetail != null;
+  const canDock = isCurrentSector && hasPort && !player.isDocked;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 sm:bg-transparent"
+        style={{ zIndex: "var(--vm-z-hud)" as unknown as number }}
+        onClick={onClose}
+      />
+
+      {/* Panel — bottom sheet on mobile, right sidebar on desktop */}
+      <div
+        className={
+          "fixed overflow-y-auto " +
+          "bottom-0 left-0 right-0 max-h-[70vh] rounded-t-xl " +
+          "sm:top-0 sm:right-0 sm:bottom-0 sm:left-auto sm:max-h-none sm:rounded-t-none sm:rounded-l-xl " +
+          "sm:w-[360px] " +
+          "animate-in slide-in-from-bottom sm:slide-in-from-right duration-200"
+        }
+        style={{
+          zIndex: "calc(var(--vm-z-hud) + 1)" as unknown as number,
+          background: "var(--vm-glass-bg)",
+          backdropFilter: `blur(var(--vm-glass-blur))`,
+          borderLeft: "1px solid var(--vm-glass-border)",
+          borderTop: "1px solid var(--vm-glass-border)",
+        }}
+      >
+        <Card className="bg-transparent border-0 shadow-none">
+          <CardHeader className="flex-row items-center justify-between">
+            <div>
+              <CardTitle className="text-[var(--vm-neutral-100)] text-lg">
+                Sector #{sector.sectorId}
+              </CardTitle>
+              {isCurrentSector && (
+                <Badge className="mt-1 border-transparent bg-[var(--vm-primary)]/20 text-[var(--vm-primary-light)] text-xs">
+                  Current Location
+                </Badge>
+              )}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="text-[var(--vm-neutral-400)] hover:text-[var(--vm-neutral-100)]"
+              aria-label="Close sector detail"
+            >
+              ✕
+            </Button>
+          </CardHeader>
+
+          <CardContent className="space-y-4">
+            {/* Warp connections */}
+            <div>
+              <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)] mb-2">
+                Warp Connections
+              </h3>
+              <div className="flex flex-wrap gap-1.5">
+                {sector.warps.map((warpId) => (
+                  <button
+                    key={warpId}
+                    onClick={() => { onSelectSector(warpId); }}
+                    className="px-2 py-1 rounded text-xs font-mono transition-colors
+                      bg-[var(--vm-neutral-800)] hover:bg-[var(--vm-primary)]/20
+                      text-[var(--vm-primary-light)] hover:text-[var(--vm-neutral-100)]
+                      cursor-pointer border border-[var(--vm-neutral-700)] hover:border-[var(--vm-primary)]/40"
+                  >
+                    #{warpId}
+                  </button>
+                ))}
+                {sector.warps.length === 0 && (
+                  <span className="text-[var(--vm-neutral-500)] text-xs italic">
+                    No warp connections
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Ships present */}
+            {sector.playerIds.length > 0 && (
+              <div>
+                <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)] mb-2">
+                  Ships Present
+                </h3>
+                <div className="flex flex-wrap gap-1.5">
+                  {sector.playerIds.map((pid) => (
+                    <Badge
+                      key={pid}
+                      variant="secondary"
+                      className="text-xs font-mono"
+                    >
+                      {pid}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Port info */}
+            {sector.portDetail && (
+              <div>
+                <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)] mb-2">
+                  Port
+                </h3>
+                <div className="rounded-lg bg-[var(--vm-neutral-900)]/60 border border-[var(--vm-neutral-800)] p-3">
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="text-[var(--vm-neutral-100)] font-medium">
+                      {sector.portDetail.name}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className="text-[var(--vm-primary-light)] border-[var(--vm-primary)]/30 text-xs font-mono"
+                    >
+                      Class {sector.portDetail.portClass}
+                    </Badge>
+                  </div>
+                  {sector.portDetail.commodities.length > 0 && (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-[var(--vm-neutral-500)] text-xs border-b border-[var(--vm-neutral-700)]">
+                          <th className="text-left py-1 font-medium">Commodity</th>
+                          <th className="text-right py-1 px-2 font-medium">Stock</th>
+                          <th className="text-right py-1 px-2 font-medium">Price</th>
+                          <th className="text-center py-1 pl-2 font-medium">Type</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sector.portDetail.commodities.map((c) => (
+                          <CommodityRow key={c.commodity} c={c} />
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              </div>
+            )}
+          </CardContent>
+
+          <CardFooter className="gap-2 flex-wrap">
+            {adjacentFromHere && (
+              <Button
+                onClick={() => { onMove(sector.sectorId); }}
+                className="bg-[var(--vm-primary)] hover:bg-[var(--vm-primary-dark)] text-white"
+              >
+                Move Here
+              </Button>
+            )}
+            {canDock && (
+              <Button
+                onClick={onDock}
+                variant="outline"
+                className="border-[var(--vm-primary)]/40 text-[var(--vm-primary-light)] hover:bg-[var(--vm-primary)]/10"
+              >
+                Dock at Port
+              </Button>
+            )}
+            {!adjacentFromHere && !canDock && !isCurrentSector && (
+              <span className="text-[var(--vm-neutral-500)] text-xs italic">
+                Not adjacent — cannot move here directly
+              </span>
+            )}
+          </CardFooter>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -1,0 +1,246 @@
+/**
+ * useGameState — React hook bridging Colyseus room state into React.
+ *
+ * Subscribes to room lifecycle and player/sector schema changes,
+ * returning plain-data snapshots that trigger React re-renders.
+ */
+import { useEffect, useState, useCallback, useRef } from "react";
+import type { Room } from "colyseus.js";
+import type {
+  GalaxyState,
+  PlayerSchema,
+  SectorSchema,
+  PortSchema,
+  CommoditySchema,
+} from "@void-market/shared";
+import {
+  subscribeToRoom,
+  subscribeToStatus,
+  type ConnectionStatus,
+} from "../network/client.js";
+import type { SectorData, PortData } from "../game/mockGalaxyData.js";
+
+// ── Plain data snapshots for React ──────────────────────────────────────────
+
+export interface PlayerSnapshot {
+  playerId: string;
+  displayName: string;
+  credits: number;
+  turnsRemaining: number;
+  turnsMax: number;
+  currentSectorId: number;
+  isDocked: boolean;
+  cargoHolds: number;
+  maxCargoHolds: number;
+}
+
+export interface CommoditySnapshot {
+  commodity: string;
+  stock: number;
+  maxStock: number;
+  buyPrice: number;
+  sellPrice: number;
+  portBuys: boolean;
+}
+
+export interface PortSnapshot extends PortData {
+  sectorId: number;
+  commodities: CommoditySnapshot[];
+}
+
+export interface SectorSnapshot extends SectorData {
+  portDetail: PortSnapshot | undefined;
+}
+
+export interface GameState {
+  currentPlayer: PlayerSnapshot | null;
+  currentSector: SectorSnapshot | null;
+  sectors: Map<number, SectorSnapshot>;
+  isConnected: boolean;
+  connectionStatus: ConnectionStatus;
+  sessionId: string | null;
+}
+
+// ── Schema → snapshot converters ────────────────────────────────────────────
+
+function playerToSnapshot(p: PlayerSchema): PlayerSnapshot {
+  return {
+    playerId: p.playerId,
+    displayName: p.displayName,
+    credits: p.credits,
+    turnsRemaining: p.turnsRemaining,
+    turnsMax: p.turnsMax,
+    currentSectorId: p.currentSectorId,
+    isDocked: p.isDocked,
+    cargoHolds: p.ship.cargoHolds,
+    maxCargoHolds: p.ship.maxCargoHolds,
+  };
+}
+
+function portToSnapshot(port: PortSchema): PortSnapshot {
+  const commodities: CommoditySnapshot[] = [];
+  (
+    port.commodities as unknown as {
+      forEach(cb: (v: CommoditySchema, k: string) => void): void;
+    }
+  ).forEach((c: CommoditySchema) => {
+    commodities.push({
+      commodity: c.commodity,
+      stock: c.stock,
+      maxStock: c.maxStock,
+      buyPrice: c.buyPrice,
+      sellPrice: c.sellPrice,
+      portBuys: c.portBuys,
+    });
+  });
+  return {
+    portId: port.portId,
+    name: port.name,
+    portClass: port.portClass,
+    sectorId: port.sectorId,
+    commodities,
+  };
+}
+
+function sectorToSnapshot(sector: SectorSchema): SectorSnapshot {
+  return {
+    sectorId: sector.sectorId,
+    x: sector.x,
+    y: sector.y,
+    warps: [...sector.warps],
+    port: sector.port
+      ? {
+          portId: sector.port.portId,
+          name: sector.port.name,
+          portClass: sector.port.portClass,
+        }
+      : undefined,
+    playerIds: [...sector.playerIds],
+    portDetail: sector.port ? portToSnapshot(sector.port) : undefined,
+  };
+}
+
+// ── Minimal typed wrappers for Colyseus MapSchema ───────────────────────────
+
+interface SchemaMap<V> {
+  onAdd(
+    cb: (item: V, key: string) => void,
+    triggerAll?: boolean,
+  ): () => boolean;
+  onRemove(cb: (item: V, key: string) => void): () => boolean;
+  onChange(cb: (item: V, key: string) => void): () => boolean;
+  get(key: string): V | undefined;
+  forEach(cb: (item: V, key: string) => void): void;
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+export function useGameState(): GameState {
+  const [state, setState] = useState<GameState>({
+    currentPlayer: null,
+    currentSector: null,
+    sectors: new Map(),
+    isConnected: false,
+    connectionStatus: "disconnected",
+    sessionId: null,
+  });
+
+  // Mutable ref to avoid stale closures in Colyseus callbacks
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const update = useCallback(
+    (patch: Partial<GameState>) => {
+      setState((prev) => ({ ...prev, ...patch }));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const detach: (() => void)[] = [];
+
+    // Connection status subscription
+    detach.push(
+      subscribeToStatus((status) => {
+        update({
+          isConnected: status === "connected",
+          connectionStatus: status,
+        });
+      }),
+    );
+
+    // Room subscription — fires when room is (re)established
+    detach.push(
+      subscribeToRoom((room: Room<GalaxyState>) => {
+        const sectors =
+          room.state.sectors as unknown as SchemaMap<SectorSchema>;
+        const players =
+          room.state.players as unknown as SchemaMap<PlayerSchema>;
+
+        const sectorMap = new Map<number, SectorSnapshot>();
+
+        /** Re-derive currentSector / currentPlayer from latest data */
+        const refresh = () => {
+          const localPlayer = players.get(room.sessionId);
+          const playerSnap = localPlayer
+            ? playerToSnapshot(localPlayer)
+            : null;
+          const currentSector = playerSnap
+            ? sectorMap.get(playerSnap.currentSectorId) ?? null
+            : null;
+
+          update({
+            currentPlayer: playerSnap,
+            currentSector: currentSector,
+            sectors: new Map(sectorMap),
+            sessionId: room.sessionId,
+          });
+        };
+
+        // Sectors
+        const detachSectorAdd = sectors.onAdd((sector) => {
+          sectorMap.set(sector.sectorId, sectorToSnapshot(sector));
+          refresh();
+        }, true);
+        detach.push(detachSectorAdd as unknown as () => void);
+
+        const detachSectorChange = sectors.onChange((sector) => {
+          sectorMap.set(sector.sectorId, sectorToSnapshot(sector));
+          refresh();
+        });
+        detach.push(detachSectorChange as unknown as () => void);
+
+        const detachSectorRemove = sectors.onRemove((_s, key) => {
+          sectorMap.delete(Number(key));
+          refresh();
+        });
+        detach.push(detachSectorRemove as unknown as () => void);
+
+        // Players
+        const detachPlayerAdd = players.onAdd(() => {
+          refresh();
+        });
+        detach.push(detachPlayerAdd as unknown as () => void);
+
+        const detachPlayerChange = players.onChange(() => {
+          refresh();
+        });
+        detach.push(detachPlayerChange as unknown as () => void);
+
+        const detachPlayerRemove = players.onRemove(() => {
+          refresh();
+        });
+        detach.push(detachPlayerRemove as unknown as () => void);
+
+        // Initial hydration
+        refresh();
+      }),
+    );
+
+    return () => {
+      for (const d of detach) d();
+    };
+  }, [update]);
+
+  return state;
+}


### PR DESCRIPTION
Adds sector detail panel with navigation/docking and always-visible HUD with turns, credits, and cargo.

## Changes

### SectorDetail panel (Issue #32)
- Slide-in panel: right sidebar on desktop, bottom sheet on mobile
- Shows sector ID, warp connections (clickable to navigate), ships present
- Port section: class badge, commodity table with stock/price/buy-sell type
- "Move Here" button for adjacent sectors (sends move via Colyseus)
- "Dock at Port" button when player is in-sector with a port

### HUD overlay (Issue #33)  
- Fixed top bar with glass-morphism styling
- Turn counter: color-coded (green >50%, amber 20-50%, red <20% of max)
- Credits display with gold accent
- Cargo progress bar (used/max holds) with color thresholds
- Current sector indicator
- Responsive: stacks vertically on mobile, horizontal on desktop

### useGameState hook
- Bridges Colyseus room state to React via subscriptions
- Returns currentPlayer, currentSector, sectors map, connection status
- Converts Colyseus Schema objects to plain React-friendly snapshots

Closes #32
Closes #33