### PR TITLE
P1-21/P1-22: Ship status panel + notification toasts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "pixi.js": "^8.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.0.0",
     "tw-animate-css": "^1.0.0"
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthScreen } from "./components/AuthScreen.js";
 import { ConnectionStatusBadge } from "./components/ConnectionStatusBadge.js";
 import { HUD } from "./components/HUD.js";
 import { SectorDetail } from "./components/SectorDetail.js";
+import { TradingPanel } from "./components/TradingPanel.js";
 import { useAuth } from "./hooks/useAuth.js";
 import { useGameState } from "./hooks/useGameState.js";
 import type { SectorSnapshot } from "./hooks/useGameState.js";
@@ -164,7 +165,20 @@ export function App(): React.JSX.Element {
 
       <ConnectionStatusBadge />
 
-      {selectedSector && (
+      {/* Trading panel when docked at a port */}
+      {gameState.currentPlayer?.isDocked &&
+        gameState.currentSector?.portDetail && (
+          <TradingPanel
+            player={gameState.currentPlayer}
+            port={gameState.currentSector.portDetail}
+            onClose={() => {
+              /* panel stays open while docked; undock closes it */
+            }}
+          />
+        )}
+
+      {/* Sector detail panel (hidden when trading) */}
+      {selectedSector && !gameState.currentPlayer?.isDocked && (
         <SectorDetail
           sector={selectedSector}
           player={gameState.currentPlayer}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { AuthScreen } from "./components/AuthScreen.js";
 import { ConnectionStatusBadge } from "./components/ConnectionStatusBadge.js";
+import { GameToaster } from "./components/GameToaster.js";
 import { HUD } from "./components/HUD.js";
 import { SectorDetail } from "./components/SectorDetail.js";
 import { TradingPanel } from "./components/TradingPanel.js";
 import { useAuth } from "./hooks/useAuth.js";
+import { useGameNotifications } from "./hooks/useGameNotifications.js";
 import { useGameState } from "./hooks/useGameState.js";
 import type { SectorSnapshot } from "./hooks/useGameState.js";
 import { initPixiApp } from "./game/PixiApp.js";
@@ -19,6 +21,7 @@ export function App(): React.JSX.Element {
   const [selectedSector, setSelectedSector] = useState<SectorSnapshot | null>(null);
 
   const gameState = useGameState();
+  useGameNotifications();
 
   // Keep a ref to the PixiJS click handler so it always uses latest closure
   const sectorClickRef = useRef<((sectorId: number) => void) | null>(null);
@@ -188,6 +191,8 @@ export function App(): React.JSX.Element {
           onSelectSector={handleSelectSector}
         />
       )}
+
+      <GameToaster />
     </>
   );
 }

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -35,6 +35,10 @@ vi.mock("../hooks/useGameState.js", () => ({
   }),
 }));
 
+vi.mock("../hooks/useGameNotifications.js", () => ({
+  useGameNotifications: vi.fn(),
+}));
+
 vi.mock("../game/PixiApp.js", () => ({
   initPixiApp: vi.fn().mockResolvedValue({
     app: {},
@@ -51,6 +55,7 @@ vi.mock("../network/client.js", () => ({
   sendDock: vi.fn(),
   sendUndock: vi.fn(),
   sendTrade: vi.fn(),
+  sendUpgradeShip: vi.fn(),
   subscribeToRoom: vi.fn().mockReturnValue(vi.fn()),
   subscribeToStatus: vi.fn().mockImplementation((cb: (s: string) => void) => {
     cb("disconnected");
@@ -93,6 +98,16 @@ vi.mock("../components/HUD.js", () => ({
 vi.mock("../components/SectorDetail.js", () => ({
   SectorDetail: () =>
     React.createElement("div", { "data-testid": "sector-detail" }),
+}));
+
+vi.mock("../components/TradingPanel.js", () => ({
+  TradingPanel: () =>
+    React.createElement("div", { "data-testid": "trading-panel" }),
+}));
+
+vi.mock("../components/GameToaster.js", () => ({
+  GameToaster: () =>
+    React.createElement("div", { "data-testid": "game-toaster" }),
 }));
 
 import { App } from "../App.js";

--- a/client/src/components/GameToaster.tsx
+++ b/client/src/components/GameToaster.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Toaster } from "sonner";
+
+/**
+ * Game-themed toast container.
+ * Wraps sonner's <Toaster> with Void Market dark-theme styling.
+ */
+export function GameToaster(): React.JSX.Element {
+  return (
+    <Toaster
+      position="bottom-right"
+      theme="dark"
+      richColors
+      toastOptions={{
+        style: {
+          fontFamily: "var(--vm-font-family-mono)",
+          fontSize: "var(--vm-font-sm)",
+          background: "var(--vm-surface-raised)",
+          border: "1px solid var(--vm-glass-border)",
+          color: "var(--vm-neutral-200)",
+        },
+      }}
+    />
+  );
+}

--- a/client/src/components/HUD.tsx
+++ b/client/src/components/HUD.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { MAX_TURN_BANK } from "@void-market/shared";
 import { Badge } from "./ui/badge.js";
+import { ShipPanel } from "./ShipPanel.js";
 import type { PlayerSnapshot } from "../hooks/useGameState.js";
 
 // ── Turn color thresholds ───────────────────────────────────────────────────
@@ -29,6 +30,8 @@ interface HUDProps {
 // ── Component ───────────────────────────────────────────────────────────────
 
 export function HUD({ player, currentSectorId }: HUDProps): React.JSX.Element | null {
+  const [shipPanelOpen, setShipPanelOpen] = useState(false);
+
   if (!player) return null;
 
   const turnsMax = player.turnsMax || MAX_TURN_BANK;
@@ -111,6 +114,35 @@ export function HUD({ player, currentSectorId }: HUDProps): React.JSX.Element | 
           </span>
         </div>
       )}
+
+      {/* Ship panel toggle */}
+      <button
+        onClick={() => { setShipPanelOpen(true); }}
+        className="ml-auto p-1.5 rounded text-[var(--vm-neutral-400)] hover:text-[var(--vm-primary-light)] hover:bg-[var(--vm-neutral-800)] transition-colors"
+        aria-label="Open ship status"
+        title="Ship Status"
+      >
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M2 20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2" />
+          <path d="M12 2L2 20h20L12 2Z" />
+          <path d="M12 10v4" />
+        </svg>
+      </button>
+
+      {/* Ship status panel */}
+      <ShipPanel
+        player={player}
+        open={shipPanelOpen}
+        onClose={() => { setShipPanelOpen(false); }}
+      />
     </div>
   );
 }

--- a/client/src/components/ShipPanel.tsx
+++ b/client/src/components/ShipPanel.tsx
@@ -1,0 +1,348 @@
+import React, { useMemo, useState } from "react";
+import { ShipClass, SHIP_SPECS, Commodity, type ShipSpec } from "@void-market/shared";
+import { Badge } from "./ui/badge.js";
+import { Button } from "./ui/button.js";
+import type { PlayerSnapshot, CargoEntry } from "../hooks/useGameState.js";
+import { sendUpgradeShip } from "../network/client.js";
+
+// ── Display helpers ──────────────────────────────────────────────────────────
+
+const SHIP_DISPLAY_NAMES: Record<string, string> = {
+  [ShipClass.Scout]: "Scout Marauder",
+  [ShipClass.Merchant]: "Merchant Freighter",
+  [ShipClass.Frigate]: "Frigate",
+  [ShipClass.Cruiser]: "Cruiser",
+  [ShipClass.Dreadnought]: "Dreadnought",
+};
+
+const SHIP_ORDER: ShipClass[] = [
+  ShipClass.Scout,
+  ShipClass.Merchant,
+  ShipClass.Frigate,
+  ShipClass.Cruiser,
+  ShipClass.Dreadnought,
+];
+
+const COMMODITY_COLORS: Record<string, string> = {
+  [Commodity.FuelOre]: "var(--vm-fuel-ore)",
+  [Commodity.Organics]: "var(--vm-organics)",
+  [Commodity.Equipment]: "var(--vm-equipment)",
+};
+
+const COMMODITY_LABELS: Record<string, string> = {
+  [Commodity.FuelOre]: "Fuel Ore",
+  [Commodity.Organics]: "Organics",
+  [Commodity.Equipment]: "Equipment",
+};
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+interface ShipPanelProps {
+  player: PlayerSnapshot;
+  open: boolean;
+  onClose: () => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function ShipPanel({ player, open, onClose }: ShipPanelProps): React.JSX.Element | null {
+  const [upgradeTarget, setUpgradeTarget] = useState<ShipClass | null>(null);
+
+  const cargoPct = player.maxCargoHolds > 0
+    ? Math.round((player.cargoHolds / player.maxCargoHolds) * 100)
+    : 0;
+
+  const currentSpec = SHIP_SPECS[player.shipClass as ShipClass];
+  const currentIdx = SHIP_ORDER.indexOf(player.shipClass as ShipClass);
+
+  const availableUpgrades = useMemo(() => {
+    return SHIP_ORDER.filter((_cls, idx) => idx > currentIdx);
+  }, [currentIdx]);
+
+  const targetSpec: ShipSpec | null = upgradeTarget ? SHIP_SPECS[upgradeTarget] : null;
+  const tradeInValue = Math.floor(currentSpec.cost * 0.5);
+  const upgradeCost = targetSpec ? Math.max(0, targetSpec.cost - tradeInValue) : 0;
+
+  const handleUpgrade = () => {
+    if (upgradeTarget) {
+      sendUpgradeShip(upgradeTarget as string);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[var(--vm-z-modal)] flex justify-end"
+      role="dialog"
+      aria-label="Ship Status"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <aside
+        className="relative w-full max-w-sm overflow-y-auto border-l animate-in slide-in-from-right duration-200"
+        style={{
+          background: "var(--vm-surface)",
+          borderColor: "var(--vm-glass-border)",
+          fontFamily: "var(--vm-font-family-mono)",
+          fontSize: "var(--vm-font-sm)",
+        }}
+      >
+        {/* Header */}
+        <div
+          className="sticky top-0 z-10 flex items-center justify-between px-4 py-3 border-b"
+          style={{
+            background: "var(--vm-surface-raised)",
+            borderColor: "var(--vm-glass-border)",
+          }}
+        >
+          <div className="flex items-center gap-2">
+            <ShipIcon className="w-5 h-5 text-[var(--vm-primary)]" />
+            <h2 className="text-[var(--vm-neutral-100)] font-semibold text-base">
+              Ship Status
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded text-[var(--vm-neutral-400)] hover:text-[var(--vm-neutral-100)] hover:bg-[var(--vm-neutral-800)] transition-colors"
+            aria-label="Close ship panel"
+          >
+            <CloseIcon className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-5">
+          {/* Ship Type */}
+          <section>
+            <div className="flex items-center gap-2 mb-1">
+              <Badge className="border-transparent bg-[var(--vm-primary)]/15 text-[var(--vm-primary-light)]">
+                {SHIP_DISPLAY_NAMES[player.shipClass] ?? player.shipClass}
+              </Badge>
+            </div>
+            <div className="flex gap-4 mt-2 text-xs text-[var(--vm-neutral-400)]">
+              <span>Speed: <span className="text-[var(--vm-neutral-200)]">{player.shipSpeed}</span></span>
+              <span>Holds: <span className="text-[var(--vm-neutral-200)]">{player.maxCargoHolds}</span></span>
+            </div>
+          </section>
+
+          {/* Cargo Capacity */}
+          <section>
+            <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)] mb-2">
+              Cargo Capacity
+            </h3>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 h-3 rounded-full bg-[var(--vm-neutral-800)] overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-all duration-300"
+                  style={{
+                    width: `${cargoPct}%`,
+                    backgroundColor:
+                      cargoPct > 90 ? "var(--vm-danger)"
+                        : cargoPct > 60 ? "var(--vm-warning)"
+                          : "var(--vm-primary)",
+                  }}
+                />
+              </div>
+              <span className="text-xs text-[var(--vm-neutral-300)] min-w-[4rem] text-right">
+                {player.cargoHolds} / {player.maxCargoHolds}
+              </span>
+            </div>
+          </section>
+
+          {/* Commodity Breakdown */}
+          <section>
+            <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)] mb-2">
+              Cargo Manifest
+            </h3>
+            <div className="space-y-2">
+              {player.cargo.length === 0 ? (
+                <p className="text-xs text-[var(--vm-neutral-600)] italic">
+                  Cargo holds empty
+                </p>
+              ) : (
+                player.cargo.map((entry: CargoEntry) => (
+                  <CommodityRow
+                    key={entry.commodity}
+                    entry={entry}
+                    maxHolds={player.maxCargoHolds}
+                  />
+                ))
+              )}
+            </div>
+          </section>
+
+          {/* Ship Upgrade (only when docked) */}
+          {player.isDocked && availableUpgrades.length > 0 && (
+            <section
+              className="border rounded-lg p-3"
+              style={{ borderColor: "var(--vm-glass-border)" }}
+            >
+              <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)] mb-3">
+                Ship Upgrade
+              </h3>
+
+              {/* Upgrade target selector */}
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {availableUpgrades.map((cls) => (
+                  <button
+                    key={cls}
+                    onClick={() => { setUpgradeTarget(cls); }}
+                    className={`px-2 py-1 rounded text-xs transition-colors border ${
+                      upgradeTarget === cls
+                        ? "border-[var(--vm-primary)] bg-[var(--vm-primary)]/15 text-[var(--vm-primary-light)]"
+                        : "border-[var(--vm-neutral-700)] text-[var(--vm-neutral-400)] hover:border-[var(--vm-neutral-500)]"
+                    }`}
+                  >
+                    {SHIP_DISPLAY_NAMES[cls] ?? cls}
+                  </button>
+                ))}
+              </div>
+
+              {/* Comparison */}
+              {upgradeTarget && targetSpec && (
+                <div className="space-y-3">
+                  <div
+                    className="grid grid-cols-3 gap-2 text-xs border rounded p-2"
+                    style={{ borderColor: "var(--vm-neutral-800)" }}
+                  >
+                    <div className="text-[var(--vm-neutral-500)]" />
+                    <div className="text-center text-[var(--vm-neutral-400)]">Current</div>
+                    <div className="text-center text-[var(--vm-primary-light)]">New</div>
+
+                    <div className="text-[var(--vm-neutral-400)]">Cargo</div>
+                    <div className="text-center text-[var(--vm-neutral-200)]">{currentSpec.cargoCapacity}</div>
+                    <StatDiff current={currentSpec.cargoCapacity} next={targetSpec.cargoCapacity} />
+
+                    <div className="text-[var(--vm-neutral-400)]">Speed</div>
+                    <div className="text-center text-[var(--vm-neutral-200)]">{currentSpec.warpSpeed}</div>
+                    <StatDiff current={currentSpec.warpSpeed} next={targetSpec.warpSpeed} />
+
+                    <div className="text-[var(--vm-neutral-400)]">Shields</div>
+                    <div className="text-center text-[var(--vm-neutral-200)]">{currentSpec.maxShields}</div>
+                    <StatDiff current={currentSpec.maxShields} next={targetSpec.maxShields} />
+
+                    <div className="text-[var(--vm-neutral-400)]">Fighters</div>
+                    <div className="text-center text-[var(--vm-neutral-200)]">{currentSpec.maxFighters}</div>
+                    <StatDiff current={currentSpec.maxFighters} next={targetSpec.maxFighters} />
+                  </div>
+
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-[var(--vm-neutral-400)]">
+                      Cost: <span className="text-[var(--vm-credits)] font-semibold">
+                        {upgradeCost.toLocaleString()} cr
+                      </span>
+                    </span>
+                    {tradeInValue > 0 && (
+                      <span className="text-[var(--vm-neutral-600)]">
+                        (trade-in: {tradeInValue.toLocaleString()} cr)
+                      </span>
+                    )}
+                  </div>
+
+                  <Button
+                    onClick={handleUpgrade}
+                    disabled={player.credits < upgradeCost}
+                    className="w-full bg-[var(--vm-primary)] hover:bg-[var(--vm-primary-dark)] text-white text-xs"
+                    size="sm"
+                  >
+                    {player.credits < upgradeCost
+                      ? `Need ${(upgradeCost - player.credits).toLocaleString()} more credits`
+                      : `Upgrade to ${SHIP_DISPLAY_NAMES[upgradeTarget] ?? upgradeTarget}`}
+                  </Button>
+                </div>
+              )}
+            </section>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function CommodityRow({ entry, maxHolds }: { entry: CargoEntry; maxHolds: number }) {
+  const pct = maxHolds > 0 ? Math.round((entry.quantity / maxHolds) * 100) : 0;
+  const color = COMMODITY_COLORS[entry.commodity] ?? "var(--vm-neutral-400)";
+  const label = COMMODITY_LABELS[entry.commodity] ?? entry.commodity;
+
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="w-2 h-2 rounded-full shrink-0"
+        style={{ backgroundColor: color }}
+      />
+      <span className="text-xs text-[var(--vm-neutral-300)] w-20 truncate">
+        {label}
+      </span>
+      <div className="flex-1 h-2 rounded-full bg-[var(--vm-neutral-800)] overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all duration-300"
+          style={{ width: `${pct}%`, backgroundColor: color }}
+        />
+      </div>
+      <span className="text-xs text-[var(--vm-neutral-400)] min-w-[2.5rem] text-right">
+        {entry.quantity}
+      </span>
+    </div>
+  );
+}
+
+function StatDiff({ current, next }: { current: number; next: number }) {
+  const diff = next - current;
+  const color =
+    diff > 0 ? "var(--vm-success)" : diff < 0 ? "var(--vm-danger)" : "var(--vm-neutral-400)";
+  return (
+    <div className="text-center" style={{ color }}>
+      {next}
+      {diff !== 0 && (
+        <span className="ml-0.5 text-[10px]">
+          ({diff > 0 ? "+" : ""}{diff})
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Inline SVG icons ─────────────────────────────────────────────────────────
+
+function ShipIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2" />
+      <path d="M12 2L2 20h20L12 2Z" />
+      <path d="M12 10v4" />
+    </svg>
+  );
+}
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1={18} y1={6} x2={6} y2={18} />
+      <line x1={6} y1={6} x2={18} y2={18} />
+    </svg>
+  );
+}

--- a/client/src/components/TradingPanel.tsx
+++ b/client/src/components/TradingPanel.tsx
@@ -1,0 +1,531 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from "./ui/card.js";
+import { Button } from "./ui/button.js";
+import { Badge } from "./ui/badge.js";
+import { Input } from "./ui/input.js";
+import type {
+  PlayerSnapshot,
+  PortSnapshot,
+  CommoditySnapshot,
+} from "../hooks/useGameState.js";
+import { sendTrade, sendUndock, getRoom } from "../network/client.js";
+import { SERVER_MSG, type TradeResultMessage } from "@void-market/shared";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TRADE_TURN_COST = 2;
+
+const COMMODITY_LABELS: Record<string, string> = {
+  fuel_ore: "Fuel Ore",
+  organics: "Organics",
+  equipment: "Equipment",
+};
+
+const COMMODITY_COLORS: Record<string, string> = {
+  fuel_ore: "var(--vm-fuel-ore)",
+  organics: "var(--vm-organics)",
+  equipment: "var(--vm-equipment)",
+};
+
+// ── Trade Result State ───────────────────────────────────────────────────────
+
+interface TradeResult {
+  success: boolean;
+  commodity: string;
+  quantity: number;
+  totalPrice: number;
+  profitLoss: number;
+  newCredits: number;
+  buying: boolean;
+  error?: string;
+}
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+interface TradingPanelProps {
+  player: PlayerSnapshot;
+  port: PortSnapshot;
+  onClose: () => void;
+}
+
+// ── Commodity Trade Row ──────────────────────────────────────────────────────
+
+function CommodityTradeRow({
+  commodity,
+  player,
+  quantities,
+  onQuantityChange,
+  onTrade,
+  pendingCommodity,
+}: {
+  commodity: CommoditySnapshot;
+  player: PlayerSnapshot;
+  quantities: Record<string, number>;
+  onQuantityChange: (commodity: string, qty: number) => void;
+  onTrade: (commodity: string, buying: boolean) => void;
+  pendingCommodity: string | null;
+}): React.JSX.Element {
+  const label = COMMODITY_LABELS[commodity.commodity] ?? commodity.commodity;
+  const color = COMMODITY_COLORS[commodity.commodity] ?? "var(--vm-neutral-400)";
+  const qty = quantities[commodity.commodity] ?? 1;
+  const playerCargo =
+    player.cargo.find((c) => c.commodity === commodity.commodity)?.quantity ?? 0;
+  const freeHolds = player.maxCargoHolds - player.cargoHolds;
+  const isPending = pendingCommodity === commodity.commodity;
+
+  // Port buys from player → player can SELL
+  // Port sells to player → player can BUY
+  const canPlayerBuy = !commodity.portBuys;
+  const canPlayerSell = commodity.portBuys;
+
+  const buyPrice = commodity.buyPrice;
+  const sellPrice = commodity.sellPrice;
+
+  // Disable conditions for buying
+  const buyDisabled =
+    !canPlayerBuy ||
+    isPending ||
+    qty <= 0 ||
+    player.turnsRemaining < TRADE_TURN_COST ||
+    player.credits < buyPrice * qty ||
+    freeHolds < qty ||
+    commodity.stock < qty;
+
+  // Disable conditions for selling
+  const sellDisabled =
+    !canPlayerSell ||
+    isPending ||
+    qty <= 0 ||
+    player.turnsRemaining < TRADE_TURN_COST ||
+    playerCargo < qty;
+
+  const maxBuyQty = canPlayerBuy
+    ? Math.min(
+        freeHolds,
+        commodity.stock,
+        buyPrice > 0 ? Math.floor(player.credits / buyPrice) : 0,
+      )
+    : 0;
+  const maxSellQty = canPlayerSell ? playerCargo : 0;
+
+  const handleMax = () => {
+    const max = canPlayerBuy ? maxBuyQty : maxSellQty;
+    onQuantityChange(commodity.commodity, Math.max(1, max));
+  };
+
+  return (
+    <div className="rounded-lg bg-[var(--vm-neutral-900)]/60 border border-[var(--vm-neutral-800)] p-3 space-y-2">
+      {/* Commodity header */}
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-2">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: color }}
+          />
+          <span className="text-[var(--vm-neutral-100)] font-medium">
+            {label}
+          </span>
+        </span>
+        <Badge
+          variant="outline"
+          className={
+            commodity.portBuys
+              ? "text-[var(--vm-success)] border-[var(--vm-success)]/30 text-xs"
+              : "text-[var(--vm-danger)] border-[var(--vm-danger)]/30 text-xs"
+          }
+        >
+          {commodity.portBuys ? "Port Buying" : "Port Selling"}
+        </Badge>
+      </div>
+
+      {/* Price and stock info */}
+      <div className="grid grid-cols-3 gap-2 text-xs">
+        <div>
+          <span className="text-[var(--vm-neutral-500)]">Stock</span>
+          <p className="font-mono text-[var(--vm-neutral-200)]">
+            {commodity.stock.toLocaleString()}
+          </p>
+        </div>
+        <div>
+          <span className="text-[var(--vm-neutral-500)]">
+            {canPlayerBuy ? "Buy Price" : "Sell Price"}
+          </span>
+          <p className="font-mono text-[var(--vm-neutral-200)]">
+            {(canPlayerBuy ? buyPrice : sellPrice).toLocaleString()} cr
+          </p>
+        </div>
+        <div>
+          <span className="text-[var(--vm-neutral-500)]">Your Cargo</span>
+          <p className="font-mono text-[var(--vm-neutral-200)]">
+            {playerCargo.toLocaleString()}
+          </p>
+        </div>
+      </div>
+
+      {/* Quantity controls and trade button */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0 border-[var(--vm-neutral-700)] text-[var(--vm-neutral-300)]"
+          onClick={() => {
+            onQuantityChange(commodity.commodity, Math.max(1, qty - 1));
+          }}
+        >
+          −
+        </Button>
+        <Input
+          type="number"
+          min={1}
+          max={canPlayerBuy ? maxBuyQty : maxSellQty}
+          value={qty}
+          onChange={(e) => {
+            onQuantityChange(
+              commodity.commodity,
+              Math.max(1, parseInt(e.target.value, 10) || 1),
+            );
+          }}
+          className="h-8 w-20 text-center font-mono text-sm bg-[var(--vm-neutral-900)] border-[var(--vm-neutral-700)] text-[var(--vm-neutral-100)]"
+        />
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0 border-[var(--vm-neutral-700)] text-[var(--vm-neutral-300)]"
+          onClick={() => { onQuantityChange(commodity.commodity, qty + 1); }}
+        >
+          +
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 border-[var(--vm-neutral-700)] text-[var(--vm-neutral-400)] text-xs"
+          onClick={handleMax}
+        >
+          Max
+        </Button>
+
+        {canPlayerBuy && (
+          <Button
+            disabled={buyDisabled}
+            onClick={() => { onTrade(commodity.commodity, true); }}
+            className="ml-auto h-8 bg-[var(--vm-success)]/90 hover:bg-[var(--vm-success)] text-white text-xs font-medium disabled:opacity-40"
+          >
+            {isPending ? "…" : `Buy ${qty}`}
+          </Button>
+        )}
+        {canPlayerSell && (
+          <Button
+            disabled={sellDisabled}
+            onClick={() => { onTrade(commodity.commodity, false); }}
+            className="ml-auto h-8 bg-[var(--vm-fuel-ore)]/90 hover:bg-[var(--vm-fuel-ore)] text-white text-xs font-medium disabled:opacity-40"
+          >
+            {isPending ? "…" : `Sell ${qty}`}
+          </Button>
+        )}
+      </div>
+
+      {/* Turn cost inline */}
+      <div className="flex items-center gap-1 text-xs text-[var(--vm-neutral-500)]">
+        <span>⏱</span>
+        <span>Costs {TRADE_TURN_COST} turns</span>
+        {canPlayerBuy && qty > 0 && (
+          <span className="ml-auto font-mono text-[var(--vm-neutral-400)]">
+            Total: {(buyPrice * qty).toLocaleString()} cr
+          </span>
+        )}
+        {canPlayerSell && qty > 0 && (
+          <span className="ml-auto font-mono text-[var(--vm-neutral-400)]">
+            Total: {(sellPrice * qty).toLocaleString()} cr
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Trade Result Toast ───────────────────────────────────────────────────────
+
+function TradeResultToast({
+  result,
+  onDismiss,
+}: {
+  result: TradeResult;
+  onDismiss: () => void;
+}): React.JSX.Element {
+  const label = COMMODITY_LABELS[result.commodity] ?? result.commodity;
+
+  useEffect(() => {
+    const timer = setTimeout(() => { onDismiss(); }, 5000);
+    return () => { clearTimeout(timer); };
+  }, [onDismiss]);
+
+  return (
+    <div
+      className={`rounded-lg border p-3 text-sm animate-in slide-in-from-top duration-200 ${
+        result.success
+          ? "bg-[var(--vm-success)]/10 border-[var(--vm-success)]/30 text-[var(--vm-success)]"
+          : "bg-[var(--vm-danger)]/10 border-[var(--vm-danger)]/30 text-[var(--vm-danger)]"
+      }`}
+    >
+      {result.success ? (
+        <>
+          <p className="font-medium">
+            ✓ {result.buying ? "Purchased" : "Sold"} {result.quantity} × {label}
+          </p>
+          <p className="text-xs mt-1 opacity-80">
+            {result.buying ? "Cost" : "Earned"}:{" "}
+            {result.totalPrice.toLocaleString()} credits
+            {result.profitLoss !== 0 && (
+              <span
+                className={
+                  result.profitLoss > 0
+                    ? "text-[var(--vm-success)]"
+                    : "text-[var(--vm-danger)]"
+                }
+              >
+                {" "}
+                ({result.profitLoss > 0 ? "+" : ""}
+                {result.profitLoss.toLocaleString()} profit)
+              </span>
+            )}
+          </p>
+          <p className="text-xs mt-0.5 opacity-70">
+            Balance: {result.newCredits.toLocaleString()} credits
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="font-medium">✗ Trade Failed</p>
+          <p className="text-xs mt-1 opacity-80">
+            {result.error ?? "Unknown error"}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Main Component ───────────────────────────────────────────────────────────
+
+export function TradingPanel({
+  player,
+  port,
+  onClose,
+}: TradingPanelProps): React.JSX.Element {
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [tradeResult, setTradeResult] = useState<TradeResult | null>(null);
+  const [pendingCommodity, setPendingCommodity] = useState<string | null>(null);
+
+  // Listen for trade result messages from the server
+  useEffect(() => {
+    const room = getRoom();
+    if (!room) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const removeListener: () => void = room.onMessage(
+      SERVER_MSG.TRADE_RESULT,
+      (msg: TradeResultMessage) => {
+        const buying = !port.commodities.find(
+          (c) => c.commodity === msg.commodity,
+        )?.portBuys;
+        setTradeResult({
+          success: msg.success,
+          commodity: msg.commodity,
+          quantity: msg.quantity,
+          totalPrice: msg.totalPrice,
+          profitLoss: msg.profitLoss,
+          newCredits: msg.newCredits,
+          buying,
+          error: msg.error,
+        });
+        setPendingCommodity(null);
+      },
+    );
+
+    return () => {
+      removeListener();
+    };
+  }, [port.commodities]);
+
+  const handleQuantityChange = useCallback(
+    (commodity: string, qty: number) => {
+      setQuantities((prev) => ({ ...prev, [commodity]: qty }));
+    },
+    [],
+  );
+
+  const handleTrade = useCallback(
+    (commodity: string, buying: boolean) => {
+      const qty = quantities[commodity] ?? 1;
+      if (qty <= 0) return;
+      setPendingCommodity(commodity);
+      setTradeResult(null);
+      sendTrade(commodity, qty, buying);
+    },
+    [quantities],
+  );
+
+  const handleUndock = useCallback(() => {
+    sendUndock();
+    onClose();
+  }, [onClose]);
+
+  const handleDismissResult = useCallback(() => {
+    setTradeResult(null);
+  }, []);
+
+  const freeHolds = player.maxCargoHolds - player.cargoHolds;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/40 sm:bg-transparent"
+        style={{ zIndex: "var(--vm-z-hud)" as unknown as number }}
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        className={
+          "fixed overflow-y-auto " +
+          "bottom-0 left-0 right-0 max-h-[85vh] rounded-t-xl " +
+          "sm:top-0 sm:right-0 sm:bottom-0 sm:left-auto sm:max-h-none sm:rounded-t-none sm:rounded-l-xl " +
+          "sm:w-[400px] " +
+          "animate-in slide-in-from-bottom sm:slide-in-from-right duration-200"
+        }
+        style={{
+          zIndex: "calc(var(--vm-z-hud) + 1)" as unknown as number,
+          background: "var(--vm-glass-bg)",
+          backdropFilter: "blur(var(--vm-glass-blur))",
+          borderLeft: "1px solid var(--vm-glass-border)",
+          borderTop: "1px solid var(--vm-glass-border)",
+        }}
+      >
+        <Card className="bg-transparent border-0 shadow-none">
+          {/* Header */}
+          <CardHeader className="flex-row items-center justify-between pb-2">
+            <div>
+              <CardTitle className="text-[var(--vm-neutral-100)] text-lg">
+                {port.name}
+              </CardTitle>
+              <div className="flex items-center gap-2 mt-1">
+                <Badge
+                  variant="outline"
+                  className="text-[var(--vm-primary-light)] border-[var(--vm-primary)]/30 text-xs font-mono"
+                >
+                  Class {port.portClass}
+                </Badge>
+                <Badge
+                  variant="outline"
+                  className="text-[var(--vm-neutral-400)] border-[var(--vm-neutral-700)] text-xs font-mono"
+                >
+                  Sector #{port.sectorId}
+                </Badge>
+              </div>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="text-[var(--vm-neutral-400)] hover:text-[var(--vm-neutral-100)]"
+              aria-label="Close trading panel"
+            >
+              ✕
+            </Button>
+          </CardHeader>
+
+          <CardContent className="space-y-3 pt-0">
+            {/* Trade result toast */}
+            {tradeResult && (
+              <TradeResultToast
+                result={tradeResult}
+                onDismiss={handleDismissResult}
+              />
+            )}
+
+            {/* Player status bar */}
+            <div className="grid grid-cols-3 gap-2 rounded-lg bg-[var(--vm-neutral-900)]/80 border border-[var(--vm-neutral-800)] p-2 text-xs">
+              <div className="text-center">
+                <span className="text-[var(--vm-neutral-500)]">Credits</span>
+                <p className="font-mono text-[var(--vm-credits)] font-medium">
+                  {player.credits.toLocaleString()}
+                </p>
+              </div>
+              <div className="text-center">
+                <span className="text-[var(--vm-neutral-500)]">Cargo</span>
+                <p className="font-mono text-[var(--vm-neutral-200)]">
+                  {player.cargoHolds}/{player.maxCargoHolds}
+                  <span className="text-[var(--vm-neutral-500)] ml-1">
+                    ({freeHolds} free)
+                  </span>
+                </p>
+              </div>
+              <div className="text-center">
+                <span className="text-[var(--vm-neutral-500)]">Turns</span>
+                <p
+                  className={`font-mono font-medium ${
+                    player.turnsRemaining < TRADE_TURN_COST
+                      ? "text-[var(--vm-danger)]"
+                      : player.turnsRemaining < 10
+                        ? "text-[var(--vm-warning)]"
+                        : "text-[var(--vm-neutral-200)]"
+                  }`}
+                >
+                  {player.turnsRemaining.toLocaleString()}/{player.turnsMax.toLocaleString()}
+                </p>
+              </div>
+            </div>
+
+            {/* Insufficient turns warning */}
+            {player.turnsRemaining < TRADE_TURN_COST && (
+              <div className="rounded-lg bg-[var(--vm-danger)]/10 border border-[var(--vm-danger)]/30 p-2 text-xs text-[var(--vm-danger)]">
+                ⚠ Not enough turns to trade. You need {TRADE_TURN_COST} turns
+                but have {player.turnsRemaining}.
+              </div>
+            )}
+
+            {/* Commodity rows */}
+            <div className="space-y-2">
+              <h3 className="text-xs uppercase tracking-wider text-[var(--vm-neutral-400)]">
+                Market
+              </h3>
+              {port.commodities.map((c) => (
+                <CommodityTradeRow
+                  key={c.commodity}
+                  commodity={c}
+                  player={player}
+                  quantities={quantities}
+                  onQuantityChange={handleQuantityChange}
+                  onTrade={handleTrade}
+                  pendingCommodity={pendingCommodity}
+                />
+              ))}
+              {port.commodities.length === 0 && (
+                <p className="text-[var(--vm-neutral-500)] text-sm italic">
+                  No commodities available at this port.
+                </p>
+              )}
+            </div>
+          </CardContent>
+
+          <CardFooter>
+            <Button
+              onClick={handleUndock}
+              variant="outline"
+              className="w-full border-[var(--vm-danger)]/40 text-[var(--vm-danger)] hover:bg-[var(--vm-danger)]/10"
+            >
+              Undock from Port
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/client/src/hooks/useGameNotifications.ts
+++ b/client/src/hooks/useGameNotifications.ts
@@ -1,0 +1,110 @@
+/**
+ * useGameNotifications — listens to Colyseus server messages and triggers toasts.
+ *
+ * Covers: trade results, movement, errors, system broadcasts, and turn regen milestones.
+ */
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import type { Room } from "colyseus.js";
+import {
+  SERVER_MSG,
+  type GalaxyState,
+  type TradeResultMessage,
+  type ErrorMessage,
+  type SectorEnteredMessage,
+  type TurnUpdateMessage,
+  type SystemMessage,
+} from "@void-market/shared";
+import { subscribeToRoom } from "../network/client.js";
+
+const TURN_MILESTONE_INTERVAL = 100;
+
+export function useGameNotifications(): void {
+  const lastTurnMilestoneRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let onTradeResult: ((msg: TradeResultMessage) => void) | null = null;
+    let onError: ((msg: ErrorMessage) => void) | null = null;
+    let onSectorEntered: ((msg: SectorEnteredMessage) => void) | null = null;
+    let onTurnUpdate: ((msg: TurnUpdateMessage) => void) | null = null;
+    let onSystem: ((msg: SystemMessage) => void) | null = null;
+
+    const unsubRoom = subscribeToRoom((room: Room<GalaxyState>) => {
+      // Trade result
+      onTradeResult = (msg: TradeResultMessage) => {
+        if (msg.success) {
+          const action = msg.profitLoss >= 0 ? "Earned" : "Spent";
+          const amount = Math.abs(msg.profitLoss);
+          toast.success(
+            `Trade complete: ${msg.quantity} ${formatCommodity(msg.commodity)}`,
+            {
+              description: `${action} ${amount.toLocaleString()} credits`,
+              duration: 4000,
+            },
+          );
+        } else {
+          toast.error("Trade failed", {
+            description: msg.error ?? "Unknown error",
+            duration: 5000,
+          });
+        }
+      };
+      room.onMessage(SERVER_MSG.TRADE_RESULT, onTradeResult);
+
+      // Error
+      onError = (msg: ErrorMessage) => {
+        toast.error(msg.message, { duration: 5000 });
+      };
+      room.onMessage(SERVER_MSG.ERROR, onError);
+
+      // Sector entered (own movement — only show for local player-relevant events)
+      onSectorEntered = (msg: SectorEnteredMessage) => {
+        if (msg.playerId === room.sessionId) {
+          toast(`Warped to Sector #${msg.sectorId}`, { duration: 2500 });
+        }
+      };
+      room.onMessage(SERVER_MSG.SECTOR_ENTERED, onSectorEntered);
+
+      // Turn update — show milestone toasts
+      onTurnUpdate = (msg: TurnUpdateMessage) => {
+        const milestone =
+          Math.floor(msg.turnsRemaining / TURN_MILESTONE_INTERVAL) *
+          TURN_MILESTONE_INTERVAL;
+
+        if (
+          lastTurnMilestoneRef.current !== null &&
+          milestone > lastTurnMilestoneRef.current
+        ) {
+          toast(`Turn regenerated (${msg.turnsRemaining}/${msg.turnsMax})`, {
+            duration: 3000,
+          });
+        }
+        lastTurnMilestoneRef.current = milestone;
+      };
+      room.onMessage(SERVER_MSG.TURN_UPDATE, onTurnUpdate);
+
+      // System broadcast
+      onSystem = (msg: SystemMessage) => {
+        const variant =
+          msg.severity === "critical"
+            ? "error"
+            : msg.severity === "warning"
+              ? "warning"
+              : "info";
+        toast[variant](msg.message, { duration: 6000 });
+      };
+      room.onMessage(SERVER_MSG.SYSTEM, onSystem);
+    });
+
+    return () => {
+      unsubRoom();
+    };
+  }, []);
+}
+
+function formatCommodity(raw: string): string {
+  return raw
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -12,6 +12,7 @@ import type {
   SectorSchema,
   PortSchema,
   CommoditySchema,
+  CargoSchema,
 } from "@void-market/shared";
 import {
   subscribeToRoom,
@@ -22,6 +23,11 @@ import type { SectorData, PortData } from "../game/mockGalaxyData.js";
 
 // ── Plain data snapshots for React ──────────────────────────────────────────
 
+export interface CargoEntry {
+  commodity: string;
+  quantity: number;
+}
+
 export interface PlayerSnapshot {
   playerId: string;
   displayName: string;
@@ -30,8 +36,11 @@ export interface PlayerSnapshot {
   turnsMax: number;
   currentSectorId: number;
   isDocked: boolean;
+  shipClass: string;
+  shipSpeed: number;
   cargoHolds: number;
   maxCargoHolds: number;
+  cargo: CargoEntry[];
 }
 
 export interface CommoditySnapshot {
@@ -64,6 +73,12 @@ export interface GameState {
 // ── Schema → snapshot converters ────────────────────────────────────────────
 
 function playerToSnapshot(p: PlayerSchema): PlayerSnapshot {
+  const cargo: CargoEntry[] = [];
+  (p.ship.cargo as unknown as { forEach(cb: (v: CargoSchema) => void): void }).forEach(
+    (c: CargoSchema) => {
+      cargo.push({ commodity: c.commodity, quantity: c.quantity });
+    },
+  );
   return {
     playerId: p.playerId,
     displayName: p.displayName,
@@ -72,8 +87,11 @@ function playerToSnapshot(p: PlayerSchema): PlayerSnapshot {
     turnsMax: p.turnsMax,
     currentSectorId: p.currentSectorId,
     isDocked: p.isDocked,
+    shipClass: p.ship.shipClass,
+    shipSpeed: p.ship.speed,
     cargoHolds: p.ship.cargoHolds,
     maxCargoHolds: p.ship.maxCargoHolds,
+    cargo,
   };
 }
 

--- a/client/src/network/client.ts
+++ b/client/src/network/client.ts
@@ -205,3 +205,10 @@ export function sendTrade(
     buying,
   });
 }
+
+export function sendUpgradeShip(targetShipClass: string): void {
+  roomInstance?.send(CLIENT_MSG.UPGRADE_SHIP, {
+    type: CLIENT_MSG.UPGRADE_SHIP,
+    targetShipClass,
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "pixi.js": "^8.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.0.0",
         "tw-animate-css": "^1.0.0"
       },
@@ -7237,6 +7238,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -87,6 +87,7 @@ export type {
   UndockMessage,
   SectorScanMessage,
   PortQueryMessage,
+  UpgradeShipMessage,
   ClientMessage,
   ServerMessageType,
   ErrorMessage,

--- a/shared/src/messages/ClientMessages.ts
+++ b/shared/src/messages/ClientMessages.ts
@@ -13,6 +13,7 @@ export const CLIENT_MSG = {
   UNDOCK: "undock",
   SECTOR_SCAN: "sector_scan",
   PORT_QUERY: "port_query",
+  UPGRADE_SHIP: "upgrade_ship",
 } as const;
 
 export type ClientMessageType = (typeof CLIENT_MSG)[keyof typeof CLIENT_MSG];
@@ -56,6 +57,12 @@ export interface PortQueryMessage {
   readonly portId: string;
 }
 
+/** Request to upgrade the player's ship to a new class. */
+export interface UpgradeShipMessage {
+  readonly type: typeof CLIENT_MSG.UPGRADE_SHIP;
+  readonly targetShipClass: string;
+}
+
 // ── Discriminated Union ──────────────────────────────────────────────────────
 
 /** Union of all client→server messages. */
@@ -65,4 +72,5 @@ export type ClientMessage =
   | DockMessage
   | UndockMessage
   | SectorScanMessage
-  | PortQueryMessage;
+  | PortQueryMessage
+  | UpgradeShipMessage;

--- a/shared/src/messages/index.ts
+++ b/shared/src/messages/index.ts
@@ -13,6 +13,7 @@ export {
   type UndockMessage,
   type SectorScanMessage,
   type PortQueryMessage,
+  type UpgradeShipMessage,
   type ClientMessage,
 } from "./ClientMessages.js";
 


### PR DESCRIPTION
Adds ship status panel with cargo breakdown and upgrade UI, plus sonner-based toast notification system for game events.

## Ship Status Panel (#35)
- Slide-out panel accessible from HUD ship icon button
- Ship type display with badge (Scout Marauder, Merchant Freighter, etc.)
- Cargo capacity bar (used/max) with color thresholds
- Commodity breakdown with per-item visual bars (Fuel Ore, Organics, Equipment)
- Ship upgrade section (visible when docked): side-by-side stat comparison, cost with trade-in value, upgrade button
- Added `UPGRADE_SHIP` client message type and `sendUpgradeShip` sender

## Notification Toast System (#36)
- GameToaster component wrapping sonner with dark game-themed styling
- useGameNotifications hook listening to Colyseus server messages
- Trade result → success/error toast with profit/loss details
- Error messages → red error toast
- Sector entered → brief "Warped to Sector #X" toast
- Turn regen milestones → subtle notification every 100 turns
- System broadcasts → severity-appropriate toasts

## Changes
- `client/src/components/ShipPanel.tsx` — new
- `client/src/components/GameToaster.tsx` — new
- `client/src/hooks/useGameNotifications.ts` — new
- `client/src/components/HUD.tsx` — ship panel toggle button
- `client/src/App.tsx` — mount GameToaster + useGameNotifications
- `client/src/hooks/useGameState.ts` — shipClass/shipSpeed in PlayerSnapshot
- `client/src/network/client.ts` — sendUpgradeShip
- `shared/src/messages/ClientMessages.ts` — UPGRADE_SHIP message type
- Updated test mocks for new dependencies

Closes #35
Closes #36